### PR TITLE
Add Gradle build scans

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,19 @@
+plugins {
+    id("com.gradle.enterprise") version("3.11.1")
+}
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 rootProject.name = "thecodinglove-kmp"
 
 apply {
     from("modules.gradle.kts")
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        publishAlways()
+    }
 }


### PR DESCRIPTION
## What does this pull request change?

This PR adds support for Gradle build scans.

## Screenshots

Local build|A build scan
-|-
<img width="395" alt="Screenshot 2022-09-21 at 20 34 42" src="https://user-images.githubusercontent.com/7644787/191583736-13ef1a74-e666-40fc-b285-205ef199d58a.png">|<img width="1679" alt="Screenshot 2022-09-21 at 20 35 13" src="https://user-images.githubusercontent.com/7644787/191583868-f00d5649-5602-4c4d-906c-856ec2d02456.png">

## How is this change tested?

Manually

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
