### PR TITLE
Use build folder instead of functions to save time

### DIFF
--- a/.github/workflows/check_build_firebase.yml
+++ b/.github/workflows/check_build_firebase.yml
@@ -30,7 +30,7 @@ jobs:
           path: '~/.konan/**'
           key: konan-js-build
       - name: Compile Javascript app
-        run: set -o pipefail && bash ./deploy/build.sh functions
+        run: set -o pipefail && bash ./deploy/build.sh
       - name: Save artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/deploy_build_firebase.yml
+++ b/.github/workflows/deploy_build_firebase.yml
@@ -30,7 +30,7 @@ jobs:
           path: '~/.konan/**'
           key: konan-js-deploy
       - name: Compile Javascript app
-        run: set -o pipefail && bash ./deploy/build.sh functions
+        run: set -o pipefail && bash ./deploy/build.sh
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ node_modules/
 .idea
 
 # Firebase
-functions/*
 .firebase/
 firebase-debug.log*
 firebase-debug.*.log*

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,6 +1,3 @@
-# Builds the project and moves executable files to a target folder
+# Builds the project
 set -e
 ./gradlew assemble
-rm -rf "$1"
-mkdir -p "$1"
-cp -R build/js/. "$1"

--- a/deploy/run_local_firebase.sh
+++ b/deploy/run_local_firebase.sh
@@ -1,4 +1,4 @@
 # Builds and runs the project locally with the Firebase Emulator
 set -e
-sh ./deploy/build.sh functions
+sh ./deploy/build.sh
 firebase serve

--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
       "firebase-debug.log",
       "firebase-debug.*.log"
     ],
-    "source": "functions",
+    "source": "build/js",
     "runtime": "nodejs16"
   }
 }


### PR DESCRIPTION
## What does this pull request change?

This PR uses build folder instead of functions to save time.

## How is this change tested?

Manually

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
