### PR TITLE
Add search config containing pages per page constant

### DIFF
--- a/appJs/appApiJs/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMainApi.kt
+++ b/appJs/appApiJs/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMainApi.kt
@@ -25,10 +25,7 @@ internal actual fun serveApi(args: Array<String>) {
                     sessionId = it
                 )
             } ?: SearchType.NewSession(searchQuery)
-            val searchResult = search(
-                searchType = searchType,
-                resultsPerPage = 4
-            )
+            val searchResult = search(searchType)
             val result = searchResult.toResult()
             val jsonResponse = Json.encodeToString(result)
             response.send(jsonResponse)

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/SearchDataModule.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/SearchDataModule.kt
@@ -5,6 +5,7 @@ import com.gchristov.thecodinglove.kmpcommonfirebase.CommonFirebaseModule
 import com.gchristov.thecodinglove.kmpcommonnetwork.CommonNetworkModule
 import com.gchristov.thecodinglove.kmphtmlparse.HtmlParseModule
 import com.gchristov.thecodinglove.kmphtmlparse.HtmlPostParser
+import com.gchristov.thecodinglove.kmpsearchdata.model.SearchConfig
 import dev.gitlive.firebase.firestore.FirebaseFirestore
 import io.ktor.client.*
 import org.kodein.di.DI
@@ -24,6 +25,7 @@ object SearchDataModule : DiModule() {
                     firebaseFirestore = instance()
                 )
             }
+            bindSingleton { provideSearchConfig() }
         }
     }
 
@@ -46,4 +48,6 @@ object SearchDataModule : DiModule() {
         htmlPostParser = htmlPostParser,
         firebaseFirestore = firebaseFirestore
     )
+
+    private fun provideSearchConfig(): SearchConfig = SearchConfig(postsPerPage = 4)
 }

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/model/SearchConfig.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/model/SearchConfig.kt
@@ -1,0 +1,5 @@
+package com.gchristov.thecodinglove.kmpsearchdata.model
+
+data class SearchConfig(
+    val postsPerPage: Int
+)

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchUseCase.kt
@@ -15,7 +15,6 @@ interface SearchUseCase {
         query: String,
         totalPosts: Int? = null,
         searchHistory: Map<Int, List<Int>>,
-        resultsPerPage: Int
     ) : Result
 
     sealed class Result {

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchWithSessionUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchWithSessionUseCase.kt
@@ -10,10 +10,7 @@ Use-case to search for a random post, wrapping it within a search session. This 
 - if the search results are exhausted, clears the search history and retries the search
  */
 interface SearchWithSessionUseCase {
-    suspend operator fun invoke(
-        searchType: SearchType,
-        resultsPerPage: Int
-    ): Result
+    suspend operator fun invoke(searchType: SearchType): Result
 
     sealed class Result {
         object Empty : Result()

--- a/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/FakeSearchUseCase.kt
+++ b/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/FakeSearchUseCase.kt
@@ -17,7 +17,6 @@ class FakeSearchUseCase(
         query: String,
         totalPosts: Int?,
         searchHistory: Map<Int, List<Int>>,
-        resultsPerPage: Int
     ): SearchUseCase.Result = searchResponse.execute(invocationResults[invocations++])
 
     fun assertInvokedOnce() {

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/SearchModule.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/SearchModule.kt
@@ -6,6 +6,7 @@ import com.gchristov.thecodinglove.kmpsearch.usecase.RealSearchUseCase
 import com.gchristov.thecodinglove.kmpsearch.usecase.RealSearchWithSessionUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.SearchDataModule
 import com.gchristov.thecodinglove.kmpsearchdata.SearchRepository
+import com.gchristov.thecodinglove.kmpsearchdata.model.SearchConfig
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithSessionUseCase
 import kotlinx.coroutines.Dispatchers
@@ -17,11 +18,16 @@ object SearchModule : DiModule() {
 
     override fun bindLocalDependencies(builder: DI.Builder) {
         builder.apply {
-            bindProvider { provideSearchUseCase(searchRepository = inject()) }
+            bindProvider {
+                provideSearchUseCase(
+                    searchRepository = inject(),
+                    searchConfig = inject()
+                )
+            }
             bindProvider {
                 provideSearchWithSessionUseCase(
                     searchRepository = inject(),
-                    searchUseCase = inject()
+                    searchUseCase = inject(),
                 )
             }
         }
@@ -32,10 +38,12 @@ object SearchModule : DiModule() {
     }
 
     private fun provideSearchUseCase(
-        searchRepository: SearchRepository
+        searchRepository: SearchRepository,
+        searchConfig: SearchConfig
     ): SearchUseCase = RealSearchUseCase(
         dispatcher = Dispatchers.Default,
-        searchRepository = searchRepository
+        searchRepository = searchRepository,
+        searchConfig = searchConfig
     )
 
     private fun provideSearchWithSessionUseCase(

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchUseCase.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchUseCase.kt
@@ -2,6 +2,7 @@ package com.gchristov.thecodinglove.kmpsearch.usecase
 
 import com.gchristov.thecodinglove.kmpsearch.*
 import com.gchristov.thecodinglove.kmpsearchdata.SearchRepository
+import com.gchristov.thecodinglove.kmpsearchdata.model.SearchConfig
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,13 +10,13 @@ import kotlin.random.Random
 
 internal class RealSearchUseCase(
     private val dispatcher: CoroutineDispatcher,
-    private val searchRepository: SearchRepository
+    private val searchRepository: SearchRepository,
+    private val searchConfig: SearchConfig
 ) : SearchUseCase {
     override suspend operator fun invoke(
         query: String,
         totalPosts: Int?,
         searchHistory: Map<Int, List<Int>>,
-        resultsPerPage: Int
     ): SearchUseCase.Result = withContext(dispatcher) {
         val totalResults = totalPosts ?: searchRepository.getTotalPosts(query)
         if (totalResults <= 0) {
@@ -23,7 +24,7 @@ internal class RealSearchUseCase(
         }
         val randomPostPage = Random.nextRandomPage(
             totalResults = totalResults,
-            resultsPerPage = resultsPerPage,
+            resultsPerPage = searchConfig.postsPerPage,
             exclusions = searchHistory.getExcludedPages()
         )
         when (randomPostPage) {

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCase.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCase.kt
@@ -13,27 +13,22 @@ import kotlin.random.Random
 internal class RealSearchWithSessionUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val searchRepository: SearchRepository,
-    private val searchUseCase: SearchUseCase
+    private val searchUseCase: SearchUseCase,
 ) : SearchWithSessionUseCase {
     override suspend operator fun invoke(
-        searchType: SearchType,
-        resultsPerPage: Int
+        searchType: SearchType
     ): SearchWithSessionUseCase.Result = withContext(dispatcher) {
         val searchSession = getSearchSession(searchType)
         val searchResult = searchUseCase(
             query = searchSession.query,
             totalPosts = searchSession.totalPosts,
             searchHistory = searchSession.searchHistory,
-            resultsPerPage = resultsPerPage
         )
         when (searchResult) {
             is SearchUseCase.Result.Empty -> SearchWithSessionUseCase.Result.Empty
             is SearchUseCase.Result.Exhausted -> {
                 clearSearchSessionHistory(searchSession)
-                invoke(
-                    searchType = searchType,
-                    resultsPerPage = resultsPerPage
-                )
+                invoke(searchType = searchType)
             }
 
             is SearchUseCase.Result.Valid -> {

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.gchristov.thecodinglove.kmpcommontest.FakeCoroutineDispatcher
 import com.gchristov.thecodinglove.kmpsearch.contains
 import com.gchristov.thecodinglove.kmpsearch.insert
 import com.gchristov.thecodinglove.kmpsearchdata.model.Post
+import com.gchristov.thecodinglove.kmpsearchdata.model.SearchConfig
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchUseCase
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchRepository
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.PostCreator
@@ -20,7 +21,6 @@ class RealSearchUseCaseTest {
     @Test
     fun searchWithNoResultsReturnsEmpty(): TestResult {
         val totalPosts = 0
-        val resultsPerPage = PostCreator.multiPageMultiPostPageSize()
         val pages = PostCreator.multiPageMultiPost()
 
         return runBlockingTest(
@@ -30,7 +30,6 @@ class RealSearchUseCaseTest {
             val actualResult = it.invoke(
                 query = SearchQuery,
                 searchHistory = mutableMapOf(),
-                resultsPerPage = resultsPerPage
             )
             assertEquals(
                 expected = SearchUseCase.Result.Empty,
@@ -42,7 +41,6 @@ class RealSearchUseCaseTest {
     @Test
     fun searchWithEmptyResultsReturnsEmpty(): TestResult {
         val totalPosts = 0
-        val resultsPerPage = PostCreator.multiPageMultiPostPageSize()
         val pages: Map<Int, List<Post>> = emptyMap()
 
         return runBlockingTest(
@@ -52,7 +50,6 @@ class RealSearchUseCaseTest {
             val actualResult = it.invoke(
                 query = SearchQuery,
                 searchHistory = mutableMapOf(),
-                resultsPerPage = resultsPerPage
             )
             assertEquals(
                 expected = SearchUseCase.Result.Empty,
@@ -64,7 +61,6 @@ class RealSearchUseCaseTest {
     @Test
     fun searchWithOneResultReturnsPost(): TestResult {
         val totalPosts = 1
-        val resultsPerPage = PostCreator.multiPageMultiPostPageSize()
         val pages = PostCreator.singlePageSinglePost()
 
         return runBlockingTest(
@@ -74,7 +70,6 @@ class RealSearchUseCaseTest {
             val actualResult = it.invoke(
                 query = SearchQuery,
                 searchHistory = mutableMapOf(),
-                resultsPerPage = resultsPerPage
             )
             assertEquals(
                 expected = SearchUseCase.Result.Valid(
@@ -93,7 +88,6 @@ class RealSearchUseCaseTest {
     @Test
     fun searchExcludes(): TestResult {
         val totalPosts = PostCreator.multiPageMultiPostTotalCount()
-        val resultsPerPage = PostCreator.multiPageMultiPostPageSize()
         val pages = PostCreator.multiPageMultiPost()
 
         return runBlockingTest(
@@ -110,7 +104,6 @@ class RealSearchUseCaseTest {
                 val actualResult = it.invoke(
                     query = SearchQuery,
                     searchHistory = searchHistory,
-                    resultsPerPage = resultsPerPage
                 ) as SearchUseCase.Result.Valid
                 // Ensure post isn't already picked
                 assertFalse {
@@ -134,7 +127,6 @@ class RealSearchUseCaseTest {
     @Test
     fun searchExhausts(): TestResult {
         val totalPosts = PostCreator.multiPageMultiPostTotalCount()
-        val resultsPerPage = PostCreator.multiPageMultiPostPageSize()
         val pages = PostCreator.multiPageMultiPost()
 
         return runBlockingTest(
@@ -147,7 +139,6 @@ class RealSearchUseCaseTest {
                 val actualResult = it.invoke(
                     query = SearchQuery,
                     searchHistory = searchHistory,
-                    resultsPerPage = resultsPerPage
                 ) as SearchUseCase.Result.Valid
                 searchHistory.insert(
                     postPage = actualResult.postPage,
@@ -168,7 +159,6 @@ class RealSearchUseCaseTest {
             val actualResult = it.invoke(
                 query = SearchQuery,
                 searchHistory = searchHistory,
-                resultsPerPage = PostCreator.multiPageMultiPostPageSize()
             )
             assertTrue { actualResult == SearchUseCase.Result.Exhausted }
         }
@@ -185,10 +175,14 @@ class RealSearchUseCaseTest {
         )
         val useCase = RealSearchUseCase(
             dispatcher = FakeCoroutineDispatcher,
-            searchRepository = searchRepository
+            searchRepository = searchRepository,
+            searchConfig = SearchConfig
         )
         testBlock(useCase)
     }
 }
 
 private const val SearchQuery = "test"
+private val SearchConfig = SearchConfig(
+    postsPerPage = PostCreator.multiPageMultiPostPageSize()
+)

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
@@ -23,10 +23,7 @@ class RealSearchWithSessionUseCaseTest {
             singleSearchInvocationResult = searchResult,
             searchSession = null,
         ) { useCase, searchRepository, searchUseCase ->
-            useCase.invoke(
-                searchType = searchType,
-                resultsPerPage = PostCreator.multiPageMultiPostPageSize()
-            )
+            useCase.invoke(searchType)
             searchUseCase.assertInvokedOnce()
             searchRepository.assertSessionNotFetched()
         }
@@ -48,10 +45,7 @@ class RealSearchWithSessionUseCaseTest {
             singleSearchInvocationResult = searchResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchUseCase ->
-            useCase.invoke(
-                searchType = searchType,
-                resultsPerPage = PostCreator.multiPageMultiPostPageSize()
-            )
+            useCase.invoke(searchType = searchType)
             searchUseCase.assertInvokedOnce()
             searchRepository.assertSessionFetched()
         }
@@ -66,10 +60,7 @@ class RealSearchWithSessionUseCaseTest {
             singleSearchInvocationResult = searchResult,
             searchSession = null,
         ) { useCase, _, searchUseCase ->
-            val actualResult = useCase.invoke(
-                searchType = searchType,
-                resultsPerPage = PostCreator.multiPageMultiPostPageSize()
-            )
+            val actualResult = useCase.invoke(searchType)
             searchUseCase.assertInvokedOnce()
             assertEquals(
                 expected = SearchWithSessionUseCase.Result.Empty,
@@ -99,10 +90,7 @@ class RealSearchWithSessionUseCaseTest {
             multiSearchInvocationResults = searchResults,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchUseCase ->
-            useCase.invoke(
-                searchType = searchType,
-                resultsPerPage = PostCreator.multiPageMultiPostPageSize()
-            )
+            useCase.invoke(searchType)
             searchUseCase.assertInvokedTwice()
             searchRepository.assertSessionSaved(
                 SearchSession(
@@ -139,10 +127,7 @@ class RealSearchWithSessionUseCaseTest {
             singleSearchInvocationResult = searchResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchUseCase ->
-            val actualResult = useCase.invoke(
-                searchType = searchType,
-                resultsPerPage = PostCreator.multiPageMultiPostPageSize()
-            )
+            val actualResult = useCase.invoke(searchType)
             searchUseCase.assertInvokedOnce()
             assertEquals(
                 expected = expectedSearchWithSessionResult,


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR takes out the `postsPerPage` constant into a new `SearchConfig` class for easier access throughout the app.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
