### PR TITLE
Replace random session identifiers with UUIDs

### DIFF
--- a/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/Deps.kt
+++ b/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/Deps.kt
@@ -3,16 +3,14 @@ package com.gchristov.thecodinglove.gradleplugins
 @Suppress("unused")
 class Deps {
     object Firebase {
-        private const val firebaseVersion = "1.6.2"
-        const val firestore = "dev.gitlive:firebase-firestore:$firebaseVersion"
+        const val firestore = "dev.gitlive:firebase-firestore:1.6.2"
         val firebase = NpmDependency("firebase", "9.10.0")
         val admin = NpmDependency("firebase-admin", "11.0.1")
         val functions = NpmDependency("firebase-functions", "3.24.0")
     }
 
     object Kodein {
-        private const val kodeinVersion = "7.15.0"
-        const val di = "org.kodein.di:kodein-di:$kodeinVersion"
+        const val di = "org.kodein.di:kodein-di:7.15.0"
     }
 
     object Kotlin {
@@ -39,6 +37,10 @@ class Deps {
     object Node {
         val htmlParser = NpmDependency("node-html-parser", "6.1.4")
         val express = NpmDependency("express", "4.18.2")
+    }
+
+    object Uuid {
+        val uuid = "com.benasher44:uuid:0.6.0"
     }
 }
 

--- a/kmp/kmp-common-kotlin/build.gradle.kts
+++ b/kmp/kmp-common-kotlin/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(Deps.Kotlin.coroutinesCore)
+                api(Deps.Uuid.uuid)
             }
         }
     }

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/RealSearchRepository.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/RealSearchRepository.kt
@@ -50,7 +50,8 @@ internal class RealSearchRepository(
             .document(searchSession.id)
         document.set(
             data = searchSession.toApiSearchSession(),
-            encodeDefaults = true
+            encodeDefaults = true,
+            merge = true
         )
     }
 }

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCase.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCase.kt
@@ -1,5 +1,6 @@
 package com.gchristov.thecodinglove.kmpsearch.usecase
 
+import com.benasher44.uuid.uuid4
 import com.gchristov.thecodinglove.kmpsearch.insert
 import com.gchristov.thecodinglove.kmpsearchdata.SearchRepository
 import com.gchristov.thecodinglove.kmpsearchdata.model.SearchSession
@@ -8,7 +9,6 @@ import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithSessionUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlin.random.Random
 
 internal class RealSearchWithSessionUseCase(
     private val dispatcher: CoroutineDispatcher,
@@ -48,7 +48,7 @@ internal class RealSearchWithSessionUseCase(
 
     private suspend fun getSearchSession(searchType: SearchType): SearchSession {
         val newSession = SearchSession(
-            id = Random.nextInt().toString(),
+            id = uuid4().toString(),
             query = searchType.query,
             totalPosts = null,
             searchHistory = emptyMap(),


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR replaces the random session identifier integer with a UUID string. This PR also ensures Firestore documents are merged when saving, rather than overwritten.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
