### PR TITLE
Add pre-loading of search results

### DIFF
--- a/appJs/appApiJs/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMainApi.kt
+++ b/appJs/appApiJs/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMainApi.kt
@@ -18,6 +18,7 @@ internal actual fun serveApi(args: Array<String>) {
 
         // TODO: Do not use GlobalScope
         GlobalScope.launch {
+            println("Performing normal search")
             val search = SearchModule.injectSearchWithSessionUseCase()
             val searchType = searchSessionId?.let {
                 SearchType.WithSessionId(
@@ -29,6 +30,12 @@ internal actual fun serveApi(args: Array<String>) {
             val result = searchResult.toResult()
             val jsonResponse = Json.encodeToString(result)
             response.send(jsonResponse)
+            if (result is Result.Valid) {
+                println("Preloading next result")
+                val preload = SearchModule.injectPreloadSearchResultUseCase()
+                val preloadResult = preload(result.searchSessionId)
+                println("Preload result $preloadResult")
+            }
         }
     }
 }

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/api/ApiSearchSession.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/api/ApiSearchSession.kt
@@ -16,6 +16,7 @@ data class ApiSearchSession(
     // Firebase doesn't like Map<Int, List<Int>> and throws ClassCastException
     val searchHistory: Map<String, List<Int>>,
     val currentPost: ApiPost?,
+    val preloadedPost: ApiPost?,
     @Serializable(with = SessionStateSerializer::class)
     val state: State
 ) {

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/model/SearchSession.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/model/SearchSession.kt
@@ -10,6 +10,7 @@ data class SearchSession(
     // Contains visited page numbers mapped to visited post indexes on those pages
     val searchHistory: Map<Int, List<Int>>,
     val currentPost: Post?,
+    val preloadedPost: Post?,
     val state: State
 ) {
     sealed class State {
@@ -28,14 +29,15 @@ internal fun ApiSearchSession.toSearchSession() = SearchSession(
             }
         }
     },
-    currentPost = currentPost?.let {
-        Post(
-            title = it.title,
-            url = it.url,
-            imageUrl = it.imageUrl
-        )
-    },
+    currentPost = currentPost?.toPost(),
+    preloadedPost = preloadedPost?.toPost(),
     state = state.toSearchSessionState()
+)
+
+private fun ApiPost.toPost() = Post(
+    title = title,
+    url = url,
+    imageUrl = imageUrl
 )
 
 private fun ApiSearchSession.State.toSearchSessionState() = when (this) {
@@ -53,16 +55,17 @@ internal fun SearchSession.toApiSearchSession() = ApiSearchSession(
             }
         }
     },
-    currentPost = currentPost?.let {
-        ApiPost(
-            title = it.title,
-            url = it.url,
-            imageUrl = it.imageUrl
-        )
-    },
+    currentPost = currentPost?.toApiPost(),
+    preloadedPost = preloadedPost?.toApiPost(),
     state = state.toApiSearchSessionState()
 )
 
 private fun SearchSession.State.toApiSearchSessionState() = when (this) {
     is SearchSession.State.Searching -> ApiSearchSession.State.Searching
 }
+
+private fun Post.toApiPost() = ApiPost(
+    title = title,
+    url = url,
+    imageUrl = imageUrl
+)

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/PreloadSearchResultUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/PreloadSearchResultUseCase.kt
@@ -1,10 +1,10 @@
 package com.gchristov.thecodinglove.kmpsearchdata.usecase
 
 /**
-Use-case to preload the next search result for faster API responses. This use-case:
-- obtains a search session
-- performs a normal load of a post based on the current session's search history
-- persists the preloaded post in the search session
+Use-case to preload the next search result for faster API responses. Implementations should:
+- obtain the search session
+- perform a normal load of a post based on the current session's search history
+- persist the preloaded post in the search session
  */
 interface PreloadSearchResultUseCase {
     suspend operator fun invoke(searchSessionId: String) : Result

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/PreloadSearchResultUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/PreloadSearchResultUseCase.kt
@@ -1,7 +1,7 @@
 package com.gchristov.thecodinglove.kmpsearchdata.usecase
 
 /**
-Use-case to preload the next search search result for faster API responses. This use-case:
+Use-case to preload the next search result for faster API responses. This use-case:
 - obtains a search session
 - performs a normal load of a post based on the current session's search history
 - persists the preloaded post in the search session

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/PreloadSearchResultUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/PreloadSearchResultUseCase.kt
@@ -1,0 +1,17 @@
+package com.gchristov.thecodinglove.kmpsearchdata.usecase
+
+/**
+Use-case to preload the next search search result for faster API responses. This use-case:
+- obtains a search session
+- performs a normal load of a post based on the current session's search history
+- persists the preloaded post in the search session
+ */
+interface PreloadSearchResultUseCase {
+    suspend operator fun invoke(searchSessionId: String) : Result
+
+    sealed class Result {
+        object Success : Result()
+        object SessionNotFound : Result()
+        object Empty : Result()
+    }
+}

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchWithHistoryUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchWithHistoryUseCase.kt
@@ -3,12 +3,12 @@ package com.gchristov.thecodinglove.kmpsearchdata.usecase
 import com.gchristov.thecodinglove.kmpsearchdata.model.Post
 
 /**
-Use-case to search for a random post, given a search session. This use-case:
-- obtains the total results for the given query, if not provided
-- chooses a random page index based on the total number of posts and posts per page
-- obtains all posts for the given page
-- chooses a random post from the page
-- returns a summary of the search
+Use-case to search for a random post, given a search session. Implementations should:
+- obtain the total results for the given query, if not provided
+- choose a random page index based on the total number of posts and posts per page
+- obtain all posts for the given page
+- choose a random post from the page
+- return a summary of the search
  */
 interface SearchWithHistoryUseCase {
     suspend operator fun invoke(

--- a/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchWithSessionUseCase.kt
+++ b/kmp/kmp-search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchdata/usecase/SearchWithSessionUseCase.kt
@@ -3,11 +3,11 @@ package com.gchristov.thecodinglove.kmpsearchdata.usecase
 import com.gchristov.thecodinglove.kmpsearchdata.model.Post
 
 /**
-Use-case to search for a random post, wrapping it within a search session. This use-case:
-- reuses or creates a new search session + search history for the given query
-- searches for results for the given query, using the search session
-- if the search result is valid, updates the search history
-- if the search results are exhausted, clears the search history and retries the search
+Use-case to search for a random post, wrapping it within a search session. Implementations should:
+- reuse or create a new search session + search history for the given query
+- search for results for the given query, using the search session
+- if the search result is valid, update the search history
+- if the search results are exhausted, clear the search history and retry the search
  */
 interface SearchWithSessionUseCase {
     suspend operator fun invoke(searchType: SearchType): Result

--- a/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/FakeSearchWithHistoryUseCase.kt
+++ b/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/FakeSearchWithHistoryUseCase.kt
@@ -19,6 +19,13 @@ class FakeSearchWithHistoryUseCase(
         searchHistory: Map<Int, List<Int>>,
     ): SearchWithHistoryUseCase.Result = searchResponse.execute(invocationResults[invocations++])
 
+    fun assertNotInvoked() {
+        assertEquals(
+            expected = 0,
+            actual = invocations
+        )
+    }
+
     fun assertInvokedOnce() {
         assertEquals(
             expected = 1,

--- a/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/PostCreator.kt
+++ b/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/PostCreator.kt
@@ -32,4 +32,10 @@ object PostCreator {
             Post(title = "p 1 i 0", url = "url", imageUrl = "imageUrl")
         )
     )
+
+    fun defaultPost() = Post(
+        title = "post",
+        url = "url",
+        imageUrl = "imageUrl"
+    )
 }

--- a/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/SearchSessionCreator.kt
+++ b/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/SearchSessionCreator.kt
@@ -1,19 +1,21 @@
 package com.gchristov.thecodinglove.kmpsearchtestfixtures
 
+import com.gchristov.thecodinglove.kmpsearchdata.model.Post
 import com.gchristov.thecodinglove.kmpsearchdata.model.SearchSession
 
 object SearchSessionCreator {
     fun searchSession(
         id: String,
         query: String,
-        searchHistory: Map<Int, List<Int>> = emptyMap()
+        searchHistory: Map<Int, List<Int>> = emptyMap(),
+        preloadedPost: Post? = null
     ) = SearchSession(
         id = id,
         query = query,
         totalPosts = null,
         searchHistory = searchHistory,
         currentPost = null,
-        preloadedPost = null,
+        preloadedPost = preloadedPost,
         state = SearchSession.State.Searching
     )
 }

--- a/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/SearchSessionCreator.kt
+++ b/kmp/kmp-search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearchtestfixtures/SearchSessionCreator.kt
@@ -13,6 +13,7 @@ object SearchSessionCreator {
         totalPosts = null,
         searchHistory = searchHistory,
         currentPost = null,
+        preloadedPost = null,
         state = SearchSession.State.Searching
     )
 }

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/SearchModule.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/SearchModule.kt
@@ -2,11 +2,13 @@ package com.gchristov.thecodinglove.kmpsearch
 
 import com.gchristov.thecodinglove.kmpcommondi.DiModule
 import com.gchristov.thecodinglove.kmpcommondi.inject
+import com.gchristov.thecodinglove.kmpsearch.usecase.RealPreloadSearchResultUseCase
 import com.gchristov.thecodinglove.kmpsearch.usecase.RealSearchWithHistoryUseCase
 import com.gchristov.thecodinglove.kmpsearch.usecase.RealSearchWithSessionUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.SearchDataModule
 import com.gchristov.thecodinglove.kmpsearchdata.SearchRepository
 import com.gchristov.thecodinglove.kmpsearchdata.model.SearchConfig
+import com.gchristov.thecodinglove.kmpsearchdata.usecase.PreloadSearchResultUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithHistoryUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithSessionUseCase
 import kotlinx.coroutines.Dispatchers
@@ -26,6 +28,12 @@ object SearchModule : DiModule() {
             }
             bindProvider {
                 provideSearchWithSessionUseCase(
+                    searchRepository = inject(),
+                    searchWithHistoryUseCase = inject(),
+                )
+            }
+            bindProvider {
+                providePreloadSearchResultUseCase(
                     searchRepository = inject(),
                     searchWithHistoryUseCase = inject(),
                 )
@@ -55,5 +63,16 @@ object SearchModule : DiModule() {
         searchWithHistoryUseCase = searchWithHistoryUseCase
     )
 
+    private fun providePreloadSearchResultUseCase(
+        searchRepository: SearchRepository,
+        searchWithHistoryUseCase: SearchWithHistoryUseCase
+    ): PreloadSearchResultUseCase = RealPreloadSearchResultUseCase(
+        dispatcher = Dispatchers.Default,
+        searchRepository = searchRepository,
+        searchWithHistoryUseCase = searchWithHistoryUseCase
+    )
+
     fun injectSearchWithSessionUseCase(): SearchWithSessionUseCase = inject()
+
+    fun injectPreloadSearchResultUseCase(): PreloadSearchResultUseCase = inject()
 }

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCase.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCase.kt
@@ -1,0 +1,73 @@
+package com.gchristov.thecodinglove.kmpsearch.usecase
+
+import com.gchristov.thecodinglove.kmpsearch.insert
+import com.gchristov.thecodinglove.kmpsearchdata.SearchRepository
+import com.gchristov.thecodinglove.kmpsearchdata.model.SearchSession
+import com.gchristov.thecodinglove.kmpsearchdata.usecase.PreloadSearchResultUseCase
+import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithHistoryUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+internal class RealPreloadSearchResultUseCase(
+    private val dispatcher: CoroutineDispatcher,
+    private val searchRepository: SearchRepository,
+    private val searchWithHistoryUseCase: SearchWithHistoryUseCase,
+) : PreloadSearchResultUseCase {
+    override suspend operator fun invoke(
+        searchSessionId: String
+    ): PreloadSearchResultUseCase.Result = withContext(dispatcher) {
+        val searchSession = searchRepository
+            .getSearchSession(searchSessionId)
+            ?: return@withContext PreloadSearchResultUseCase.Result.SessionNotFound
+        val searchResult = searchWithHistoryUseCase(
+            query = searchSession.query,
+            totalPosts = searchSession.totalPosts,
+            searchHistory = searchSession.searchHistory,
+        )
+        when (searchResult) {
+            is SearchWithHistoryUseCase.Result.Empty -> PreloadSearchResultUseCase.Result.Empty
+            is SearchWithHistoryUseCase.Result.Exhausted -> {
+                clearSearchSessionHistory(searchSession)
+                invoke(searchSessionId = searchSessionId)
+            }
+
+            is SearchWithHistoryUseCase.Result.Valid -> {
+                insertSearchResultInSession(
+                    searchSession = searchSession,
+                    searchResult = searchResult,
+                )
+                PreloadSearchResultUseCase.Result.Success
+            }
+        }
+    }
+
+    private suspend fun insertSearchResultInSession(
+        searchSession: SearchSession,
+        searchResult: SearchWithHistoryUseCase.Result.Valid,
+    ) {
+        val updatedSearchSession = searchSession.copy(
+            totalPosts = searchResult.totalPosts,
+            searchHistory = searchSession.searchHistory.toMutableMap().apply {
+                insert(
+                    postPage = searchResult.postPage,
+                    postIndexOnPage = searchResult.postIndexOnPage,
+                    currentPageSize = searchResult.postPageSize
+                )
+            },
+            // The old preloaded post now becomes the current one, if found, and a new future one is set
+            currentPost = searchSession.preloadedPost ?: searchSession.currentPost,
+            preloadedPost = searchResult.post
+        )
+        searchRepository.saveSearchSession(updatedSearchSession)
+    }
+
+    private suspend fun clearSearchSessionHistory(searchSession: SearchSession) {
+        val updatedSearchSession = searchSession.copy(
+            searchHistory = emptyMap(),
+            // When clearing we still want to set the current post to whatever is the preloaded one
+            currentPost = searchSession.preloadedPost,
+            preloadedPost = null
+        )
+        searchRepository.saveSearchSession(updatedSearchSession)
+    }
+}

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCase.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCase.kt
@@ -46,6 +46,7 @@ internal class RealPreloadSearchResultUseCase(
         searchResult: SearchWithHistoryUseCase.Result.Valid,
     ) {
         val updatedSearchSession = searchSession.copy(
+            totalPosts = searchResult.totalPosts,
             searchHistory = searchSession.searchHistory.toMutableMap().apply {
                 insert(
                     postPage = searchResult.postPage,

--- a/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCase.kt
+++ b/kmp/kmp-search/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCase.kt
@@ -46,7 +46,6 @@ internal class RealPreloadSearchResultUseCase(
         searchResult: SearchWithHistoryUseCase.Result.Valid,
     ) {
         val updatedSearchSession = searchSession.copy(
-            totalPosts = searchResult.totalPosts,
             searchHistory = searchSession.searchHistory.toMutableMap().apply {
                 insert(
                     postPage = searchResult.postPage,

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -28,14 +28,16 @@ class RealPreloadSearchResultUseCaseTest {
 
     @Test
     fun preloadWithSessionIdReusesSession(): TestResult {
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
             query = SearchQuery
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             useCase.invoke(searchSessionId = SearchSessionId)
@@ -46,14 +48,14 @@ class RealPreloadSearchResultUseCaseTest {
 
     @Test
     fun preloadWithEmptyResultReturnsEmpty(): TestResult {
-        val searchResult = SearchWithHistoryUseCase.Result.Empty
+        val searchWithHistoryResult = SearchWithHistoryUseCase.Result.Empty
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
             query = SearchQuery
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchSessionId = SearchSessionId)
@@ -68,7 +70,7 @@ class RealPreloadSearchResultUseCaseTest {
 
     @Test
     fun preloadWithExhaustedResultClearsSearchSessionHistoryAndRetries(): TestResult {
-        val searchResults = listOf(
+        val searchWithHistoryResults = listOf(
             SearchWithHistoryUseCase.Result.Exhausted,
             SearchWithHistoryUseCase.Result.Empty
         )
@@ -81,7 +83,7 @@ class RealPreloadSearchResultUseCaseTest {
         )
 
         return runBlockingTest(
-            multiSearchInvocationResults = searchResults,
+            multiSearchWithHistoryInvocationResults = searchWithHistoryResults,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             useCase.invoke(searchSessionId = SearchSessionId)
@@ -102,7 +104,9 @@ class RealPreloadSearchResultUseCaseTest {
 
     @Test
     fun preloadUpdatesSessionAndReturnsSuccessResult(): TestResult {
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
         val oldPreloadedPost = PostCreator.defaultPost()
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
@@ -111,7 +115,7 @@ class RealPreloadSearchResultUseCaseTest {
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchSessionId = SearchSessionId)
@@ -124,10 +128,10 @@ class RealPreloadSearchResultUseCaseTest {
                 SearchSession(
                     id = searchSession.id,
                     query = SearchQuery,
-                    totalPosts = searchResult.totalPosts,
+                    totalPosts = searchWithHistoryResult.totalPosts,
                     searchHistory = mapOf(1 to listOf(0, -1)),
                     currentPost = oldPreloadedPost,
-                    preloadedPost = searchResult.post,
+                    preloadedPost = searchWithHistoryResult.post,
                     state = SearchSession.State.Searching
                 )
             )
@@ -136,7 +140,9 @@ class RealPreloadSearchResultUseCaseTest {
 
     @Test
     fun preloadKeepsCurrentPostIfNothingPreviouslyPreloaded(): TestResult {
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
             query = SearchQuery,
@@ -144,7 +150,7 @@ class RealPreloadSearchResultUseCaseTest {
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchSessionId = SearchSessionId)
@@ -157,10 +163,10 @@ class RealPreloadSearchResultUseCaseTest {
                 SearchSession(
                     id = searchSession.id,
                     query = SearchQuery,
-                    totalPosts = searchResult.totalPosts,
+                    totalPosts = searchWithHistoryResult.totalPosts,
                     searchHistory = mapOf(1 to listOf(0, -1)),
                     currentPost = searchSession.currentPost,
-                    preloadedPost = searchResult.post,
+                    preloadedPost = searchWithHistoryResult.post,
                     state = SearchSession.State.Searching
                 )
             )
@@ -168,13 +174,13 @@ class RealPreloadSearchResultUseCaseTest {
     }
 
     private fun runBlockingTest(
-        singleSearchInvocationResult: SearchWithHistoryUseCase.Result? = null,
-        multiSearchInvocationResults: List<SearchWithHistoryUseCase.Result>? = null,
+        singleSearchWithHistoryInvocationResult: SearchWithHistoryUseCase.Result? = null,
+        multiSearchWithHistoryInvocationResults: List<SearchWithHistoryUseCase.Result>? = null,
         searchSession: SearchSession?,
         testBlock: suspend (PreloadSearchResultUseCase, FakeSearchRepository, FakeSearchWithHistoryUseCase) -> Unit
     ): TestResult = runTest {
-        val searchInvocationResults = singleSearchInvocationResult?.let { listOf(it) }
-            ?: multiSearchInvocationResults
+        val searchInvocationResults = singleSearchWithHistoryInvocationResult?.let { listOf(it) }
+            ?: multiSearchWithHistoryInvocationResults
             ?: emptyList()
         val searchRepository = FakeSearchRepository(searchSession = searchSession)
         val searchWithHistoryUseCase = FakeSearchWithHistoryUseCase(

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -7,6 +7,7 @@ import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithHistoryUseCas
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchRepository
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchWithHistoryUseCase
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.SearchSessionCreator
+import com.gchristov.thecodinglove.kmpsearchtestfixtures.SearchWithHistoryResultCreator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -25,6 +26,24 @@ class RealPreloadSearchResultUseCaseTest {
                 expected = PreloadSearchResultUseCase.Result.SessionNotFound,
                 actual = actualResult
             )
+        }
+    }
+
+    @Test
+    fun preloadWithSessionIdReusesSession(): TestResult {
+        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchSession = SearchSessionCreator.searchSession(
+            id = SearchSessionId,
+            query = SearchQuery
+        )
+
+        return runBlockingTest(
+            singleSearchInvocationResult = searchResult,
+            searchSession = searchSession,
+        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+            useCase.invoke(searchSessionId = SearchSessionId)
+            searchWithHistoryUseCase.assertInvokedOnce()
+            searchRepository.assertSessionFetched()
         }
     }
 
@@ -49,24 +68,6 @@ class RealPreloadSearchResultUseCaseTest {
             )
         }
     }
-
-//    @Test
-//    fun searchWithSessionIdReusesSession(): TestResult {
-//        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
-//        val searchSession = SearchSessionCreator.searchSession(
-//            id = SearchSessionId,
-//            query = SearchQuery
-//        )
-//
-//        return runBlockingTest(
-//            singleSearchInvocationResult = searchResult,
-//            searchSession = searchSession,
-//        ) { useCase, searchRepository, searchWithHistoryUseCase ->
-//            useCase.invoke(searchSessionId = SearchSessionId)
-//            searchWithHistoryUseCase.assertInvokedOnce()
-//            searchRepository.assertSessionFetched()
-//        }
-//    }
 //
 //    @Test
 //    fun searchWithExhaustedResultClearsSearchSessionHistoryAndRetries(): TestResult {

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -4,10 +4,7 @@ import com.gchristov.thecodinglove.kmpcommontest.FakeCoroutineDispatcher
 import com.gchristov.thecodinglove.kmpsearchdata.model.SearchSession
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.PreloadSearchResultUseCase
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithHistoryUseCase
-import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchRepository
-import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchWithHistoryUseCase
-import com.gchristov.thecodinglove.kmpsearchtestfixtures.SearchSessionCreator
-import com.gchristov.thecodinglove.kmpsearchtestfixtures.SearchWithHistoryResultCreator
+import com.gchristov.thecodinglove.kmpsearchtestfixtures.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -68,44 +65,40 @@ class RealPreloadSearchResultUseCaseTest {
             )
         }
     }
-//
-//    @Test
-//    fun searchWithExhaustedResultClearsSearchSessionHistoryAndRetries(): TestResult {
-//        val searchType = SearchType.WithSessionId(
-//            query = SearchQuery,
-//            sessionId = SearchSessionId
-//        )
-//        val searchResults = listOf(
-//            SearchWithHistoryUseCase.Result.Exhausted,
-//            SearchWithHistoryUseCase.Result.Empty
-//        )
-//        val searchSession = SearchSessionCreator.searchSession(
-//            id = SearchSessionId,
-//            query = SearchQuery,
-//            searchHistory = mapOf(1 to listOf(0, 1, 2, 3))
-//        )
-//
-//        return runBlockingTest(
-//            singleSearchInvocationResult = null,
-//            multiSearchInvocationResults = searchResults,
-//            searchSession = searchSession,
-//        ) { useCase, searchRepository, searchWithHistoryUseCase ->
-//            useCase.invoke(searchType)
-//            searchWithHistoryUseCase.assertInvokedTwice()
-//            searchRepository.assertSessionSaved(
-//                SearchSession(
-//                    id = searchSession.id,
-//                    query = searchSession.query,
-//                    totalPosts = null,
-//                    searchHistory = emptyMap(),
-//                    currentPost = null,
-//                    preloadedPost = null,
-//                    state = SearchSession.State.Searching
-//                )
-//            )
-//        }
-//    }
-//
+
+    @Test
+    fun preloadWithExhaustedResultClearsSearchSessionHistoryAndRetries(): TestResult {
+        val searchResults = listOf(
+            SearchWithHistoryUseCase.Result.Exhausted,
+            SearchWithHistoryUseCase.Result.Empty
+        )
+        val searchSession = SearchSessionCreator.searchSession(
+            id = SearchSessionId,
+            query = SearchQuery,
+            searchHistory = mapOf(1 to listOf(0, 1, 2, 3)),
+            preloadedPost = PostCreator.defaultPost()
+        )
+
+        return runBlockingTest(
+            multiSearchInvocationResults = searchResults,
+            searchSession = searchSession,
+        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+            useCase.invoke(searchSessionId = SearchSessionId)
+            searchWithHistoryUseCase.assertInvokedTwice()
+            searchRepository.assertSessionSaved(
+                SearchSession(
+                    id = searchSession.id,
+                    query = searchSession.query,
+                    totalPosts = null,
+                    searchHistory = emptyMap(),
+                    currentPost = searchSession.preloadedPost,
+                    preloadedPost = null,
+                    state = SearchSession.State.Searching
+                )
+            )
+        }
+    }
+
 //    @Test
 //    fun searchUpdatesSessionAndReturnsValidResult(): TestResult {
 //        val searchType = SearchType.WithSessionId(

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -99,47 +99,38 @@ class RealPreloadSearchResultUseCaseTest {
         }
     }
 
-//    @Test
-//    fun searchUpdatesSessionAndReturnsValidResult(): TestResult {
-//        val searchType = SearchType.WithSessionId(
-//            sessionId = SearchSessionId,
-//            query = SearchQuery
-//        )
-//        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
-//        val searchSession = SearchSessionCreator.searchSession(
-//            id = SearchSessionId,
-//            query = SearchQuery
-//        )
-//        val expectedSearchWithSessionResult = SearchWithSessionUseCase.Result.Valid(
-//            searchSessionId = searchSession.id,
-//            query = searchSession.query,
-//            post = searchResult.post,
-//            totalPosts = searchResult.totalPosts
-//        )
-//
-//        return runBlockingTest(
-//            singleSearchInvocationResult = searchResult,
-//            searchSession = searchSession,
-//        ) { useCase, searchRepository, searchWithHistoryUseCase ->
-//            val actualResult = useCase.invoke(searchType)
-//            searchWithHistoryUseCase.assertInvokedOnce()
-//            assertEquals(
-//                expected = expectedSearchWithSessionResult,
-//                actual = actualResult
-//            )
-//            searchRepository.assertSessionSaved(
-//                SearchSession(
-//                    id = searchSession.id,
-//                    query = SearchQuery,
-//                    totalPosts = searchResult.totalPosts,
-//                    searchHistory = mapOf(1 to listOf(0, -1)),
-//                    currentPost = searchResult.post,
-//                    preloadedPost = null,
-//                    state = SearchSession.State.Searching
-//                )
-//            )
-//        }
-//    }
+    @Test
+    fun preloadUpdatesSessionAndReturnsSuccessResult(): TestResult {
+        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchSession = SearchSessionCreator.searchSession(
+            id = SearchSessionId,
+            query = SearchQuery,
+            preloadedPost = searchResult.post
+        )
+
+        return runBlockingTest(
+            singleSearchInvocationResult = searchResult,
+            searchSession = searchSession,
+        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+            val actualResult = useCase.invoke(searchSessionId = SearchSessionId)
+            searchWithHistoryUseCase.assertInvokedOnce()
+            assertEquals(
+                expected = PreloadSearchResultUseCase.Result.Success,
+                actual = actualResult
+            )
+            searchRepository.assertSessionSaved(
+                SearchSession(
+                    id = searchSession.id,
+                    query = SearchQuery,
+                    totalPosts = searchResult.totalPosts,
+                    searchHistory = mapOf(1 to listOf(0, -1)),
+                    currentPost = searchSession.preloadedPost,
+                    preloadedPost = searchResult.post,
+                    state = SearchSession.State.Searching
+                )
+            )
+        }
+    }
 
     private fun runBlockingTest(
         singleSearchInvocationResult: SearchWithHistoryUseCase.Result? = null,

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -1,0 +1,168 @@
+package com.gchristov.thecodinglove.kmpsearch.usecase
+
+import com.gchristov.thecodinglove.kmpcommontest.FakeCoroutineDispatcher
+import com.gchristov.thecodinglove.kmpsearchdata.model.SearchSession
+import com.gchristov.thecodinglove.kmpsearchdata.usecase.PreloadSearchResultUseCase
+import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithHistoryUseCase
+import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchRepository
+import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchWithHistoryUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RealPreloadSearchResultUseCaseTest {
+    @Test
+    fun preloadWithMissingSessionReturnsSessionNotFound(): TestResult {
+        return runBlockingTest(searchSession = null) { useCase, searchRepository, searchWithHistoryUseCase ->
+            val actualResult = useCase.invoke(searchSessionId = SearchSessionId)
+            searchRepository.assertSessionFetched()
+            searchWithHistoryUseCase.assertNotInvoked()
+            assertEquals(
+                expected = PreloadSearchResultUseCase.Result.SessionNotFound,
+                actual = actualResult
+            )
+        }
+    }
+
+//    @Test
+//    fun searchWithSessionIdReusesSession(): TestResult {
+//        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+//        val searchSession = SearchSessionCreator.searchSession(
+//            id = SearchSessionId,
+//            query = SearchQuery
+//        )
+//
+//        return runBlockingTest(
+//            singleSearchInvocationResult = searchResult,
+//            searchSession = searchSession,
+//        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+//            useCase.invoke(searchSessionId = SearchSessionId)
+//            searchWithHistoryUseCase.assertInvokedOnce()
+//            searchRepository.assertSessionFetched()
+//        }
+//    }
+//
+//    @Test
+//    fun searchWithEmptyResultReturnsEmpty(): TestResult {
+//        val searchType = SearchType.NewSession(query = SearchQuery)
+//        val searchResult = SearchWithHistoryUseCase.Result.Empty
+//
+//        return runBlockingTest(
+//            singleSearchInvocationResult = searchResult,
+//            searchSession = null,
+//        ) { useCase, _, searchWithHistoryUseCase ->
+//            val actualResult = useCase.invoke(searchType)
+//            searchWithHistoryUseCase.assertInvokedOnce()
+//            assertEquals(
+//                expected = SearchWithSessionUseCase.Result.Empty,
+//                actual = actualResult,
+//            )
+//        }
+//    }
+//
+//    @Test
+//    fun searchWithExhaustedResultClearsSearchSessionHistoryAndRetries(): TestResult {
+//        val searchType = SearchType.WithSessionId(
+//            query = SearchQuery,
+//            sessionId = SearchSessionId
+//        )
+//        val searchResults = listOf(
+//            SearchWithHistoryUseCase.Result.Exhausted,
+//            SearchWithHistoryUseCase.Result.Empty
+//        )
+//        val searchSession = SearchSessionCreator.searchSession(
+//            id = SearchSessionId,
+//            query = SearchQuery,
+//            searchHistory = mapOf(1 to listOf(0, 1, 2, 3))
+//        )
+//
+//        return runBlockingTest(
+//            singleSearchInvocationResult = null,
+//            multiSearchInvocationResults = searchResults,
+//            searchSession = searchSession,
+//        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+//            useCase.invoke(searchType)
+//            searchWithHistoryUseCase.assertInvokedTwice()
+//            searchRepository.assertSessionSaved(
+//                SearchSession(
+//                    id = searchSession.id,
+//                    query = searchSession.query,
+//                    totalPosts = null,
+//                    searchHistory = emptyMap(),
+//                    currentPost = null,
+//                    preloadedPost = null,
+//                    state = SearchSession.State.Searching
+//                )
+//            )
+//        }
+//    }
+//
+//    @Test
+//    fun searchUpdatesSessionAndReturnsValidResult(): TestResult {
+//        val searchType = SearchType.WithSessionId(
+//            sessionId = SearchSessionId,
+//            query = SearchQuery
+//        )
+//        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+//        val searchSession = SearchSessionCreator.searchSession(
+//            id = SearchSessionId,
+//            query = SearchQuery
+//        )
+//        val expectedSearchWithSessionResult = SearchWithSessionUseCase.Result.Valid(
+//            searchSessionId = searchSession.id,
+//            query = searchSession.query,
+//            post = searchResult.post,
+//            totalPosts = searchResult.totalPosts
+//        )
+//
+//        return runBlockingTest(
+//            singleSearchInvocationResult = searchResult,
+//            searchSession = searchSession,
+//        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+//            val actualResult = useCase.invoke(searchType)
+//            searchWithHistoryUseCase.assertInvokedOnce()
+//            assertEquals(
+//                expected = expectedSearchWithSessionResult,
+//                actual = actualResult
+//            )
+//            searchRepository.assertSessionSaved(
+//                SearchSession(
+//                    id = searchSession.id,
+//                    query = SearchQuery,
+//                    totalPosts = searchResult.totalPosts,
+//                    searchHistory = mapOf(1 to listOf(0, -1)),
+//                    currentPost = searchResult.post,
+//                    preloadedPost = null,
+//                    state = SearchSession.State.Searching
+//                )
+//            )
+//        }
+//    }
+
+    private fun runBlockingTest(
+        singleSearchInvocationResult: SearchWithHistoryUseCase.Result? = null,
+        multiSearchInvocationResults: List<SearchWithHistoryUseCase.Result>? = null,
+        searchSession: SearchSession?,
+        testBlock: suspend (PreloadSearchResultUseCase, FakeSearchRepository, FakeSearchWithHistoryUseCase) -> Unit
+    ): TestResult = runTest {
+        val searchInvocationResults = singleSearchInvocationResult?.let { listOf(it) }
+            ?: multiSearchInvocationResults
+            ?: emptyList()
+        val searchRepository = FakeSearchRepository(searchSession = searchSession)
+        val searchWithHistoryUseCase = FakeSearchWithHistoryUseCase(
+            invocationResults = searchInvocationResults
+        )
+        val useCase = RealPreloadSearchResultUseCase(
+            dispatcher = FakeCoroutineDispatcher,
+            searchRepository = searchRepository,
+            searchWithHistoryUseCase = searchWithHistoryUseCase
+        )
+        testBlock(useCase, searchRepository, searchWithHistoryUseCase)
+    }
+}
+
+private const val SearchQuery = "test"
+private const val SearchSessionId = "session_123"

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.gchristov.thecodinglove.kmpsearchdata.usecase.PreloadSearchResultUseC
 import com.gchristov.thecodinglove.kmpsearchdata.usecase.SearchWithHistoryUseCase
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchRepository
 import com.gchristov.thecodinglove.kmpsearchtestfixtures.FakeSearchWithHistoryUseCase
+import com.gchristov.thecodinglove.kmpsearchtestfixtures.SearchSessionCreator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -27,6 +28,28 @@ class RealPreloadSearchResultUseCaseTest {
         }
     }
 
+    @Test
+    fun preloadWithEmptyResultReturnsEmpty(): TestResult {
+        val searchResult = SearchWithHistoryUseCase.Result.Empty
+        val searchSession = SearchSessionCreator.searchSession(
+            id = SearchSessionId,
+            query = SearchQuery
+        )
+
+        return runBlockingTest(
+            singleSearchInvocationResult = searchResult,
+            searchSession = searchSession,
+        ) { useCase, searchRepository, searchWithHistoryUseCase ->
+            val actualResult = useCase.invoke(searchSessionId = SearchSessionId)
+            searchRepository.assertSessionFetched()
+            searchWithHistoryUseCase.assertInvokedOnce()
+            assertEquals(
+                expected = PreloadSearchResultUseCase.Result.Empty,
+                actual = actualResult,
+            )
+        }
+    }
+
 //    @Test
 //    fun searchWithSessionIdReusesSession(): TestResult {
 //        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
@@ -42,24 +65,6 @@ class RealPreloadSearchResultUseCaseTest {
 //            useCase.invoke(searchSessionId = SearchSessionId)
 //            searchWithHistoryUseCase.assertInvokedOnce()
 //            searchRepository.assertSessionFetched()
-//        }
-//    }
-//
-//    @Test
-//    fun searchWithEmptyResultReturnsEmpty(): TestResult {
-//        val searchType = SearchType.NewSession(query = SearchQuery)
-//        val searchResult = SearchWithHistoryUseCase.Result.Empty
-//
-//        return runBlockingTest(
-//            singleSearchInvocationResult = searchResult,
-//            searchSession = null,
-//        ) { useCase, _, searchWithHistoryUseCase ->
-//            val actualResult = useCase.invoke(searchType)
-//            searchWithHistoryUseCase.assertInvokedOnce()
-//            assertEquals(
-//                expected = SearchWithSessionUseCase.Result.Empty,
-//                actual = actualResult,
-//            )
 //        }
 //    }
 //

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithHistoryUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithHistoryUseCaseTest.kt
@@ -152,6 +152,7 @@ class RealSearchWithHistoryUseCaseTest {
                 assertTrue {
                     val historyPage = searchHistory[page]!!
                     val testPage = PostCreator.multiPageMultiPost()[page]!!
+                    // Fully visited pages have an extra -1 in the list to indicate page termination
                     historyPage.size - 1 == testPage.size
                 }
             }

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
@@ -17,10 +17,12 @@ class RealSearchWithSessionUseCaseTest {
     @Test
     fun searchWithNewSessionCreatesNewSession(): TestResult {
         val searchType = SearchType.NewSession(query = SearchQuery)
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = null,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             useCase.invoke(searchType)
@@ -35,7 +37,9 @@ class RealSearchWithSessionUseCaseTest {
             query = SearchQuery,
             sessionId = SearchSessionId
         )
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
         val preloadedPost = PostCreator.defaultPost()
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
@@ -44,7 +48,7 @@ class RealSearchWithSessionUseCaseTest {
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchType = searchType)
@@ -68,14 +72,16 @@ class RealSearchWithSessionUseCaseTest {
             query = SearchQuery,
             sessionId = SearchSessionId
         )
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
             query = SearchQuery
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             useCase.invoke(searchType = searchType)
@@ -87,10 +93,10 @@ class RealSearchWithSessionUseCaseTest {
     @Test
     fun searchWithEmptyResultReturnsEmpty(): TestResult {
         val searchType = SearchType.NewSession(query = SearchQuery)
-        val searchResult = SearchWithHistoryUseCase.Result.Empty
+        val searchWithHistoryResult = SearchWithHistoryUseCase.Result.Empty
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = null,
         ) { useCase, _, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchType)
@@ -108,7 +114,7 @@ class RealSearchWithSessionUseCaseTest {
             query = SearchQuery,
             sessionId = SearchSessionId
         )
-        val searchResults = listOf(
+        val searchWithHistoryResults = listOf(
             SearchWithHistoryUseCase.Result.Exhausted,
             SearchWithHistoryUseCase.Result.Empty
         )
@@ -119,8 +125,7 @@ class RealSearchWithSessionUseCaseTest {
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = null,
-            multiSearchInvocationResults = searchResults,
+            multiSearchWithHistoryInvocationResults = searchWithHistoryResults,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             useCase.invoke(searchType)
@@ -145,7 +150,9 @@ class RealSearchWithSessionUseCaseTest {
             sessionId = SearchSessionId,
             query = SearchQuery
         )
-        val searchResult = SearchWithHistoryResultCreator.validResult(query = SearchQuery)
+        val searchWithHistoryResult = SearchWithHistoryResultCreator.validResult(
+            query = SearchQuery
+        )
         val searchSession = SearchSessionCreator.searchSession(
             id = SearchSessionId,
             query = SearchQuery
@@ -153,12 +160,12 @@ class RealSearchWithSessionUseCaseTest {
         val expectedSearchWithSessionResult = SearchWithSessionUseCase.Result.Valid(
             searchSessionId = searchSession.id,
             query = searchSession.query,
-            post = searchResult.post,
-            totalPosts = searchResult.totalPosts
+            post = searchWithHistoryResult.post,
+            totalPosts = searchWithHistoryResult.totalPosts
         )
 
         return runBlockingTest(
-            singleSearchInvocationResult = searchResult,
+            singleSearchWithHistoryInvocationResult = searchWithHistoryResult,
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchType)
@@ -171,9 +178,9 @@ class RealSearchWithSessionUseCaseTest {
                 SearchSession(
                     id = searchSession.id,
                     query = SearchQuery,
-                    totalPosts = searchResult.totalPosts,
+                    totalPosts = searchWithHistoryResult.totalPosts,
                     searchHistory = mapOf(1 to listOf(0, -1)),
-                    currentPost = searchResult.post,
+                    currentPost = searchWithHistoryResult.post,
                     preloadedPost = null,
                     state = SearchSession.State.Searching
                 )
@@ -182,13 +189,13 @@ class RealSearchWithSessionUseCaseTest {
     }
 
     private fun runBlockingTest(
-        singleSearchInvocationResult: SearchWithHistoryUseCase.Result? = null,
-        multiSearchInvocationResults: List<SearchWithHistoryUseCase.Result>? = null,
+        singleSearchWithHistoryInvocationResult: SearchWithHistoryUseCase.Result? = null,
+        multiSearchWithHistoryInvocationResults: List<SearchWithHistoryUseCase.Result>? = null,
         searchSession: SearchSession?,
         testBlock: suspend (SearchWithSessionUseCase, FakeSearchRepository, FakeSearchWithHistoryUseCase) -> Unit
     ): TestResult = runTest {
-        val searchInvocationResults = singleSearchInvocationResult?.let { listOf(it) }
-            ?: multiSearchInvocationResults
+        val searchInvocationResults = singleSearchWithHistoryInvocationResult?.let { listOf(it) }
+            ?: multiSearchWithHistoryInvocationResults
             ?: emptyList()
         val searchRepository = FakeSearchRepository(searchSession = searchSession)
         val searchWithHistoryUseCase = FakeSearchWithHistoryUseCase(

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
@@ -99,6 +99,7 @@ class RealSearchWithSessionUseCaseTest {
                     totalPosts = null,
                     searchHistory = emptyMap(),
                     currentPost = null,
+                    preloadedPost = null,
                     state = SearchSession.State.Searching
                 )
             )
@@ -140,6 +141,7 @@ class RealSearchWithSessionUseCaseTest {
                     totalPosts = searchResult.totalPosts,
                     searchHistory = mapOf(1 to listOf(0, -1)),
                     currentPost = searchResult.post,
+                    preloadedPost = null,
                     state = SearchSession.State.Searching
                 )
             )

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
@@ -158,7 +158,9 @@ class RealSearchWithSessionUseCaseTest {
             ?: multiSearchInvocationResults
             ?: emptyList()
         val searchRepository = FakeSearchRepository(searchSession = searchSession)
-        val searchWithHistoryUseCase = FakeSearchWithHistoryUseCase(invocationResults = searchInvocationResults)
+        val searchWithHistoryUseCase = FakeSearchWithHistoryUseCase(
+            invocationResults = searchInvocationResults
+        )
         val useCase = RealSearchWithSessionUseCase(
             dispatcher = FakeCoroutineDispatcher,
             searchRepository = searchRepository,


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR adds pre-loading to search results so that further requests return results instantly.

## How is this change tested?

Manually, with new and existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
