### PR TITLE
Mark preloaded result as used and move exhausted history updates to session search

### DIFF
--- a/appJs/appApiJs/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMainApi.kt
+++ b/appJs/appApiJs/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMainApi.kt
@@ -14,6 +14,8 @@ internal actual fun serveApi(args: Array<String>) {
     exports.myTestFun = fireFunctions.https.onRequest { request, response ->
         val searchQuery = (request.query.searchQuery as? String) ?: "release"
         val searchSessionId = request.query.searchSessionId as? String
+        val test = request.body.channel_name as? String
+        println(test)
 
         // TODO: Do not use GlobalScope
         GlobalScope.launch {

--- a/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
+++ b/kmp/kmp-search/src/commonTest/kotlin/com/gchristov/thecodinglove/kmpsearch/usecase/RealSearchWithSessionUseCaseTest.kt
@@ -55,6 +55,17 @@ class RealSearchWithSessionUseCaseTest {
             val actualResult = useCase.invoke(type = searchType)
             searchWithHistoryUseCase.assertNotInvoked()
             searchRepository.assertSessionFetched()
+            searchRepository.assertSessionSaved(
+                SearchSession(
+                    id = searchSession.id,
+                    query = searchSession.query,
+                    totalPosts = searchSession.totalPosts,
+                    searchHistory = searchSession.searchHistory,
+                    currentPost = preloadedPost,
+                    preloadedPost = null,
+                    state = searchSession.state
+                )
+            )
             assertEquals(
                 expected = Either.Right(
                     SearchWithSessionUseCase.Result(


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR marks preloaded results as used and moves exhausted history updates to session search. This is to:
- not return the same result if pre-load has failed for some reason
- not mix exhausted search history behaviour between components - now, only session search handles it

## How is this change tested?

Manually, with new and existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
