### PR TITLE
Add browser user agent header to HttpClient

### DIFF
--- a/kmp/kmp-common-network/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpcommonnetwork/KmpCommonNetworkModule.kt
+++ b/kmp/kmp-common-network/src/commonMain/kotlin/com/gchristov/thecodinglove/kmpcommonnetwork/KmpCommonNetworkModule.kt
@@ -2,6 +2,7 @@ package com.gchristov.thecodinglove.kmpcommonnetwork
 
 import com.gchristov.thecodinglove.kmpcommondi.DiModule
 import io.ktor.client.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
@@ -25,6 +26,7 @@ object KmpCommonNetworkModule : DiModule() {
     }
 
     private fun provideHttpClient(jsonSerializer: Json) = HttpClient {
+        BrowserUserAgent()
         install(ContentNegotiation) {
             json(jsonSerializer)
         }


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR adds a browser user agent header to `HttpClient`.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
