### PR TITLE
Optimisation: disable PubSub publisher batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,7 @@
 
 # Setup [WIP]
 firebase init
+
 firebase init emulators
+
+[Slack API test hub](https://requestbin.com/r/eny6fd4lflem/2LzxvzhVXCw7p02t82zfRXkAvdF)

--- a/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/JavascriptGooglePubSubExternals.kt
+++ b/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/JavascriptGooglePubSubExternals.kt
@@ -7,7 +7,18 @@ import com.gchristov.thecodinglove.kmpcommonkotlin.Buffer
 
 @JsName("PubSub")
 internal external class GoogleCloudPubSub(projectId: String) {
-    fun topic(name: String): GoogleGloudPubSubTopic
+    fun topic(
+        name: String,
+        options: dynamic
+    ): GoogleGloudPubSubTopic
+}
+
+internal external class GoogleGloudPubSubPublishOptions {
+    var batching: GoogleGloudPubSubBatchOptions?
+}
+
+internal external class GoogleGloudPubSubBatchOptions {
+    var maxMessages: Int
 }
 
 internal external class GoogleGloudPubSubTopic {

--- a/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/PubSubSender.kt
+++ b/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/PubSubSender.kt
@@ -32,6 +32,21 @@ internal class RealPubSubSender(private val projectId: String) : PubSubSender {
                     "topic: $topic\n" +
                     "body: $body"
         )
-        GoogleCloudPubSub(projectId).topic(topic).publish(Buffer.from(body))
+        GoogleCloudPubSub(projectId).topic(
+            name = topic,
+            options = js(
+                """{
+                    batching: {
+                    maxMessages: 1
+                }
+                }"""
+            )
+        ).publish(Buffer.from(body))
+    }
+}
+
+private val DefaultPubSubOptions = GoogleGloudPubSubPublishOptions().apply {
+    batching = GoogleGloudPubSubBatchOptions().apply {
+        maxMessages = 1
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

Attempt to optimise PubSub by removing client message batching and sending them right away. This is to ensure that Slack slash commands are handled faster.

## How is this change tested?

Manually

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
