### PR TITLE
Optimisation: revert PubSub publisher batching and await message to be published before finishing function

### DIFF
--- a/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/JavascriptGooglePubSubExternals.kt
+++ b/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/JavascriptGooglePubSubExternals.kt
@@ -4,23 +4,13 @@
 package com.gchristov.thecodinglove.commonservicedata.pubsub
 
 import com.gchristov.thecodinglove.kmpcommonkotlin.Buffer
+import kotlin.js.Promise
 
 @JsName("PubSub")
 internal external class GoogleCloudPubSub(projectId: String) {
-    fun topic(
-        name: String,
-        options: dynamic
-    ): GoogleGloudPubSubTopic
+    fun topic(name: String): GoogleCloudPubSubTopic
 }
 
-internal external class GoogleGloudPubSubPublishOptions {
-    var batching: GoogleGloudPubSubBatchOptions?
-}
-
-internal external class GoogleGloudPubSubBatchOptions {
-    var maxMessages: Int
-}
-
-internal external class GoogleGloudPubSubTopic {
-    fun publish(message: Buffer)
+internal external class GoogleCloudPubSubTopic {
+    fun publish(message: Buffer): Promise<String>
 }

--- a/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/PubSubSender.kt
+++ b/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/pubsub/PubSubSender.kt
@@ -2,17 +2,18 @@ package com.gchristov.thecodinglove.commonservicedata.pubsub
 
 import arrow.core.Either
 import com.gchristov.thecodinglove.kmpcommonkotlin.Buffer
+import kotlinx.coroutines.await
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 interface PubSubSender {
-    fun sendMessage(
+    suspend fun sendMessage(
         topic: String,
         body: String
     )
 }
 
-inline fun <reified T> PubSubSender.sendMessage(
+suspend inline fun <reified T> PubSubSender.sendMessage(
     topic: String,
     body: T,
     jsonSerializer: Json
@@ -23,30 +24,15 @@ inline fun <reified T> PubSubSender.sendMessage(
 }
 
 internal class RealPubSubSender(private val projectId: String) : PubSubSender {
-    override fun sendMessage(
+    override suspend fun sendMessage(
         topic: String,
         body: String
     ) {
-        println(
-            "Sending PubSub message\n" +
-                    "topic: $topic\n" +
-                    "body: $body"
-        )
-        GoogleCloudPubSub(projectId).topic(
-            name = topic,
-            options = js(
-                """{
-                    batching: {
-                    maxMessages: 1
-                }
-                }"""
-            )
-        ).publish(Buffer.from(body))
-    }
-}
-
-private val DefaultPubSubOptions = GoogleGloudPubSubPublishOptions().apply {
-    batching = GoogleGloudPubSubBatchOptions().apply {
-        maxMessages = 1
+        println("Sending PubSub message: topic=$topic, body=$body")
+        val messageId = GoogleCloudPubSub(projectId)
+            .topic(topic)
+            .publish(Buffer.from(body))
+            .await()
+        println("PubSub message sent: id=$messageId")
     }
 }

--- a/backend/common-service-testfixtures/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicetestfixtures/FakePubSubSender.kt
+++ b/backend/common-service-testfixtures/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicetestfixtures/FakePubSubSender.kt
@@ -8,7 +8,7 @@ class FakePubSubSender : PubSubSender {
     private var lastBody: String? = null
     private var invocations = 0
 
-    override fun sendMessage(
+    override suspend fun sendMessage(
         topic: String,
         body: String
     ) {

--- a/backend/common-service/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservice/PubSubService.kt
+++ b/backend/common-service/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservice/PubSubService.kt
@@ -29,10 +29,6 @@ abstract class PubSubService(
         callback = { message ->
             Promise { resolve, reject ->
                 launch {
-                    println(
-                        "Received PubSub request" +
-                                "\ntopic: ${topic()}"
-                    )
                     handleMessage(message).fold(
                         ifLeft = { reject(it) },
                         ifRight = {

--- a/backend/search/src/jsMain/kotlin/com/gchristov/thecodinglove/search/SearchApiService.kt
+++ b/backend/search/src/jsMain/kotlin/com/gchristov/thecodinglove/search/SearchApiService.kt
@@ -44,7 +44,7 @@ class SearchApiService(
                 }
         }
 
-    private fun publishPreloadMessage(searchSessionId: String) = pubSubSender.sendMessage(
+    private suspend fun publishPreloadMessage(searchSessionId: String) = pubSubSender.sendMessage(
         topic = PreloadPubSubService.Topic,
         body = PreloadPubSubMessage(searchSessionId),
         jsonSerializer = jsonSerializer

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackSlashCommandApiService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackSlashCommandApiService.kt
@@ -56,7 +56,7 @@ class SlackSlashCommandApiService(
             }
     }
 
-    private fun publishSlashCommandMessage(slackSlashCommand: ApiSlackSlashCommand) =
+    private suspend fun publishSlashCommandMessage(slackSlashCommand: ApiSlackSlashCommand) =
         pubSubSender.sendMessage(
             topic = SlackSlashCommandPubSubService.Topic,
             body = slackSlashCommand.toPubSubMessage(),

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/usecase/RealVerifySlackRequestUseCase.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/usecase/RealVerifySlackRequestUseCase.kt
@@ -27,12 +27,7 @@ class RealVerifySlackRequestUseCase(
                     ?: return@withContext Either.Left(VerifySlackRequestUseCase.Error.MissingTimestamp)
                 val signature: String = request.headers["x-slack-signature"]
                     ?: return@withContext Either.Left(VerifySlackRequestUseCase.Error.MissingSignature)
-                println(
-                    "Verifying Slack request\n" +
-                            "timestamp: $timestamp\n" +
-                            "signature: $signature\n" +
-                            "body: ${request.rawBody}"
-                )
+                println("Verifying Slack request: timestamp=$timestamp, signature=$signature, body=${request.rawBody}")
 
                 verifyTimestamp(
                     timestamp = timestamp,


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR reverts the previous PubSub batching change since it wasn't the culprit behind the observed latency. Instead, as suggested by this thread, the issue was related to the cloud function not awaiting the PubSub message to be sent before terminating. The fix is to ensure the function awaits the PubSub message to be sent.

## Demo

https://user-images.githubusercontent.com/7644787/220928332-335516b6-8c2f-49e6-84c1-ec19ab63fca8.mov

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
