### PR TITLE
Remove Slack slash command web rerouting since it's too slow

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,10 +15,6 @@
       {
         "source": "/api/search",
         "function": "search"
-      },
-      {
-        "source": "/api/slack/slashcommand",
-        "function": "slackSlashCommand"
       }
     ]
   },


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR removes the web API route for the Slack slash command function since setting this up every time it's hit causes timeouts in Slack.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
