### PR TITLE
Move slash command handler to PubSub and reply instantly with empty message

### DIFF
--- a/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/api/Api.kt
+++ b/backend/common-service-data/src/jsMain/kotlin/com/gchristov/thecodinglove/commonservicedata/api/Api.kt
@@ -51,6 +51,18 @@ inline fun <reified T> ApiResponse.sendJson(
     Either.Left(error)
 }
 
+fun ApiResponse.sendEmpty(status: Int = 200): Either<Throwable, Unit> = try {
+    status(status)
+    setHeader(
+        header = "Content-Type",
+        value = "application/json"
+    )
+    send("")
+    Either.Right(Unit)
+} catch (error: Throwable) {
+    Either.Left(error)
+}
+
 internal fun FirebaseFunctionsHttpsRequest.toApiRequest() = object : ApiRequest {
     override val headers: ApiParameterMap = this@toApiRequest.headers.toApiParametersMap()
     override val query: ApiParameterMap = this@toApiRequest.query.toApiParametersMap()

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
@@ -3,7 +3,6 @@ package com.gchristov.thecodinglove.slackdata
 import com.gchristov.thecodinglove.kmpcommondi.DiModule
 import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import io.ktor.client.*
-import kotlinx.serialization.json.Json
 import org.kodein.di.DI
 import org.kodein.di.bindSingleton
 import org.kodein.di.instance
@@ -16,10 +15,7 @@ object SlackDataModule : DiModule() {
             bindSingleton { provideSlackApi(client = instance()) }
             bindSingleton { provideSlackConfig() }
             bindSingleton {
-                provideSlackRepository(
-                    api = instance(),
-                    jsonSerializer = instance()
-                )
+                provideSlackRepository(api = instance())
             }
         }
     }
@@ -33,10 +29,8 @@ object SlackDataModule : DiModule() {
     )
 
     private fun provideSlackRepository(
-        api: SlackApi,
-        jsonSerializer: Json
+        api: SlackApi
     ): SlackRepository = RealSlackRepository(
-        apiService = api,
-        jsonSerializer = jsonSerializer
+        apiService = api
     )
 }

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackRepository.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackRepository.kt
@@ -1,41 +1,22 @@
 package com.gchristov.thecodinglove.slackdata
 
 import arrow.core.Either
-import com.gchristov.thecodinglove.commonservicedata.api.ApiResponse
-import com.gchristov.thecodinglove.commonservicedata.api.sendJson
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackMessage
-import kotlinx.serialization.json.Json
 
 interface SlackRepository {
-    fun sendProcessingMessage(
-        text: String,
-        response: ApiResponse
-    ): Either<Throwable, Unit>
-
     suspend fun sendMessage(
-        messageUrl: String,
+        channelUrl: String,
         message: ApiSlackMessage
     ): Either<Throwable, Unit>
 }
 
-internal class RealSlackRepository(
-    private val apiService: SlackApi,
-    private val jsonSerializer: Json
-) : SlackRepository {
-    override fun sendProcessingMessage(
-        text: String,
-        response: ApiResponse
-    ) = response.sendJson(
-        data = ApiSlackMessage.ApiProcessing(text = text),
-        jsonSerializer = jsonSerializer
-    )
-
+internal class RealSlackRepository(private val apiService: SlackApi) : SlackRepository {
     override suspend fun sendMessage(
-        messageUrl: String,
+        channelUrl: String,
         message: ApiSlackMessage
     ) = try {
         apiService.sendMessage(
-            messageUrl = messageUrl,
+            messageUrl = channelUrl,
             message = message
         )
         Either.Right(Unit)

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
@@ -27,7 +27,6 @@ object SlackModule : DiModule() {
                     apiServiceRegister = instance(),
                     jsonSerializer = instance(),
                     verifySlackRequestUseCase = instance(),
-                    slackRepository = instance(),
                     slackConfig = instance(),
                     pubSubSender = instance()
                 )
@@ -54,14 +53,12 @@ object SlackModule : DiModule() {
         apiServiceRegister: ApiServiceRegister,
         jsonSerializer: Json,
         verifySlackRequestUseCase: VerifySlackRequestUseCase,
-        slackRepository: SlackRepository,
         slackConfig: SlackConfig,
         pubSubSender: PubSubSender,
     ): SlackSlashCommandApiService = SlackSlashCommandApiService(
         apiServiceRegister = apiServiceRegister,
         jsonSerializer = jsonSerializer,
         verifySlackRequestUseCase = verifySlackRequestUseCase,
-        slackRepository = slackRepository,
         slackConfig = slackConfig,
         pubSubSender = pubSubSender
     )

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackSlashCommandApiService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackSlashCommandApiService.kt
@@ -4,14 +4,10 @@ import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.leftIfNull
 import com.gchristov.thecodinglove.commonservice.ApiService
-import com.gchristov.thecodinglove.commonservicedata.api.ApiRequest
-import com.gchristov.thecodinglove.commonservicedata.api.ApiResponse
-import com.gchristov.thecodinglove.commonservicedata.api.ApiServiceRegister
-import com.gchristov.thecodinglove.commonservicedata.api.bodyAsJson
+import com.gchristov.thecodinglove.commonservicedata.api.*
 import com.gchristov.thecodinglove.commonservicedata.exports
 import com.gchristov.thecodinglove.commonservicedata.pubsub.PubSubSender
 import com.gchristov.thecodinglove.commonservicedata.pubsub.sendMessage
-import com.gchristov.thecodinglove.slackdata.SlackRepository
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackSlashCommand
 import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import com.gchristov.thecodinglove.slackdata.domain.toPubSubMessage
@@ -22,7 +18,6 @@ class SlackSlashCommandApiService(
     apiServiceRegister: ApiServiceRegister,
     private val jsonSerializer: Json,
     private val verifySlackRequestUseCase: VerifySlackRequestUseCase,
-    private val slackRepository: SlackRepository,
     private val slackConfig: SlackConfig,
     private val pubSubSender: PubSubSender,
 ) : ApiService(
@@ -41,17 +36,13 @@ class SlackSlashCommandApiService(
     } else {
         Either.Right(Unit)
     }.flatMap {
-        // TODO: Remove
         println(JSON.stringify(request.body))
         request.bodyAsJson<ApiSlackSlashCommand>(jsonSerializer)
             .leftIfNull(default = { Exception("Request body is null") })
             .flatMap { slashCommand ->
                 publishSlashCommandMessage(slashCommand)
                     .flatMap {
-                        slackRepository.sendProcessingMessage(
-                            text = "🔎 Hang tight, we're finding your GIF...",
-                            response = response
-                        )
+                        response.sendEmpty()
                     }
             }
     }

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackSlashCommandPubSubService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackSlashCommandPubSubService.kt
@@ -11,6 +11,7 @@ import com.gchristov.thecodinglove.commonservicedata.pubsub.bodyAsJson
 import com.gchristov.thecodinglove.slackdata.SlackRepository
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackMessage
 import com.gchristov.thecodinglove.slackdata.domain.SlackSlashCommandPubSubMessage
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 
 class SlackSlashCommandPubSubService(
@@ -27,12 +28,18 @@ class SlackSlashCommandPubSubService(
     override suspend fun handleMessage(message: PubSubMessage): Either<Throwable, Unit> =
         message.bodyAsJson<SlackSlashCommandPubSubMessage>(jsonSerializer)
             .leftIfNull(default = { Exception("Message body is null") })
-            .flatMap {
-                // TODO: This is temporary to prove functionality
+            .flatMap { slashCommand ->
                 slackRepository.sendMessage(
-                    messageUrl = it.responseUrl,
-                    message = ApiSlackMessage.ApiProcessing(text = it.text)
-                )
+                    channelUrl = slashCommand.responseUrl,
+                    message = ApiSlackMessage.ApiProcessing(text = "🔎 Hang tight, we're finding your GIF...")
+                ).flatMap {
+                    // TODO: This is temporary to prove functionality
+                    delay(1000)
+                    slackRepository.sendMessage(
+                        channelUrl = slashCommand.responseUrl,
+                        message = ApiSlackMessage.ApiProcessing(text = slashCommand.text)
+                    )
+                }
             }
 
     companion object {


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR moves the slash command handler to PubSub so that all message handling logic lives in one place. Now the slash command API service replies immediately with an empty 200 response.

## Demo

https://user-images.githubusercontent.com/7644787/221132214-ec05534d-68a5-44ff-ae3c-ab0df8a4ee28.mov

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
