### PR TITLE
Send Slack search message as ephemeral

### DIFF
--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
@@ -47,6 +47,13 @@ object SlackDataModule : DiModule() {
                     slackRepository = instance(),
                 )
             }
+            bindProvider {
+                provideSendSlackSearchUseCase(
+                    log = instance(),
+                    searchRepository = instance(),
+                    slackRepository = instance(),
+                )
+            }
         }
     }
 
@@ -95,6 +102,17 @@ object SlackDataModule : DiModule() {
         dispatcher = Dispatchers.Default,
         log = log,
         searchUseCase = searchUseCase,
+        slackRepository = slackRepository
+    )
+
+    private fun provideSendSlackSearchUseCase(
+        log: Logger,
+        searchRepository: SearchRepository,
+        slackRepository: SlackRepository,
+    ): SendSlackSearchUseCase = RealSendSlackSearchUseCase(
+        dispatcher = Dispatchers.Default,
+        log = log,
+        searchRepository = searchRepository,
         slackRepository = slackRepository
     )
 }

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackMessage.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackMessage.kt
@@ -128,6 +128,31 @@ object ApiSlackMessageFactory {
         ),
     )
 
+    fun searchPostMessage(
+        searchQuery: String,
+        attachmentTitle: String,
+        attachmentUrl: String,
+        attachmentImageUrl: String,
+    ) = ApiSlackMessage(
+        text = searchQuery,
+        userId = null,
+        channelId = null,
+        responseType = "in_channel",
+        responseUrl = null,
+        teamId = null,
+        asUser = false,
+        replaceOriginal = true,
+        deleteOriginal = false,
+        attachments = listOf(
+            attachment(
+                title = attachmentTitle,
+                url = attachmentUrl,
+                imageUrl = attachmentImageUrl,
+                actions = emptyList(),
+            )
+        ),
+    )
+
     private fun attachment(
         title: String,
         url: String,

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SendSlackSearchUseCase.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SendSlackSearchUseCase.kt
@@ -1,0 +1,46 @@
+package com.gchristov.thecodinglove.slackdata.usecase
+
+import arrow.core.Either
+import arrow.core.flatMap
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.searchdata.SearchRepository
+import com.gchristov.thecodinglove.slackdata.SlackRepository
+import com.gchristov.thecodinglove.slackdata.api.ApiSlackMessageFactory
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+interface SendSlackSearchUseCase {
+    suspend operator fun invoke(
+        messageUrl: String,
+        searchSessionId: String,
+    ): Either<Throwable, Unit>
+}
+
+class RealSendSlackSearchUseCase(
+    private val dispatcher: CoroutineDispatcher,
+    private val log: Logger,
+    private val searchRepository: SearchRepository,
+    private val slackRepository: SlackRepository,
+) : SendSlackSearchUseCase {
+    override suspend operator fun invoke(
+        messageUrl: String,
+        searchSessionId: String,
+    ): Either<Throwable, Unit> = withContext(dispatcher) {
+        log.d("Obtaining search session: searchSessionId=$searchSessionId")
+        searchRepository.getSearchSession(searchSessionId)
+            .flatMap { searchSession ->
+                slackRepository.sendMessage(
+                    messageUrl = messageUrl,
+                    message = ApiSlackMessageFactory.searchPostMessage(
+                        searchQuery = searchSession.query,
+                        attachmentTitle = searchSession.currentPost!!.title,
+                        attachmentUrl = searchSession.currentPost!!.url,
+                        attachmentImageUrl = searchSession.currentPost!!.imageUrl
+                    )
+                ).flatMap {
+                    log.d("Deleting search session: searchSessionId=$searchSessionId")
+                    searchRepository.deleteSearchSession(searchSessionId)
+                }
+            }
+    }
+}

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
@@ -13,6 +13,7 @@ import com.gchristov.thecodinglove.slack.slashcommand.SlackSlashCommandPubSubSer
 import com.gchristov.thecodinglove.slackdata.SlackRepository
 import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import com.gchristov.thecodinglove.slackdata.usecase.CancelSlackSearchUseCase
+import com.gchristov.thecodinglove.slackdata.usecase.SendSlackSearchUseCase
 import com.gchristov.thecodinglove.slackdata.usecase.ShuffleSlackSearchUseCase
 import com.gchristov.thecodinglove.slackdata.usecase.VerifySlackRequestUseCase
 import kotlinx.serialization.json.Json
@@ -59,6 +60,7 @@ object SlackModule : DiModule() {
                     pubSubServiceRegister = instance(),
                     jsonSerializer = instance(),
                     log = instance(),
+                    sendSlackSearchUseCase = instance(),
                     shuffleSlackSearchUseCase = instance(),
                     cancelSlackSearchUseCase = instance(),
                 )
@@ -116,12 +118,14 @@ object SlackModule : DiModule() {
         pubSubServiceRegister: PubSubServiceRegister,
         jsonSerializer: Json,
         log: Logger,
+        sendSlackSearchUseCase: SendSlackSearchUseCase,
         shuffleSlackSearchUseCase: ShuffleSlackSearchUseCase,
         cancelSlackSearchUseCase: CancelSlackSearchUseCase,
     ): SlackInteractivityPubSubService = SlackInteractivityPubSubService(
         pubSubServiceRegister = pubSubServiceRegister,
         jsonSerializer = jsonSerializer,
         log = log,
+        sendSlackSearchUseCase = sendSlackSearchUseCase,
         shuffleSlackSearchUseCase = shuffleSlackSearchUseCase,
         cancelSlackSearchUseCase = cancelSlackSearchUseCase,
     )


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR posts the search result as `ephemeral` in the relevant Slack channel. We cannot yet post to everyone since that requires token permissions, which will be obtained in a future PR.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
