### PR TITLE
Persist Slack authentication token in Firestore

### DIFF
--- a/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/SearchRepository.kt
+++ b/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/SearchRepository.kt
@@ -103,4 +103,4 @@ internal class RealSearchRepository(
     }
 }
 
-private const val SearchSessionCollection = "searchSession"
+private const val SearchSessionCollection = "search_session"

--- a/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/SearchRepository.kt
+++ b/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/SearchRepository.kt
@@ -4,7 +4,8 @@ import arrow.core.Either
 import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.htmlparsedata.usecase.ParseHtmlPostsUseCase
 import com.gchristov.thecodinglove.htmlparsedata.usecase.ParseHtmlTotalPostsUseCase
-import com.gchristov.thecodinglove.searchdata.api.ApiSearchSession
+import com.gchristov.thecodinglove.searchdata.db.DbSearchSession
+import com.gchristov.thecodinglove.searchdata.db.toSearchSession
 import com.gchristov.thecodinglove.searchdata.model.*
 import dev.gitlive.firebase.firestore.FirebaseFirestore
 import io.ktor.client.statement.*
@@ -63,8 +64,8 @@ internal class RealSearchRepository(
             .document(id)
             .get()
         if (document.exists) {
-            val apiSearchSession: ApiSearchSession = document.data()
-            Either.Right(apiSearchSession.toSearchSession())
+            val dbSearchSession: DbSearchSession = document.data()
+            Either.Right(dbSearchSession.toSearchSession())
         } else {
             Either.Left(SearchError.SessionNotFound)
         }

--- a/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/db/DbPost.kt
+++ b/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/db/DbPost.kt
@@ -1,0 +1,18 @@
+package com.gchristov.thecodinglove.searchdata.db
+
+import com.gchristov.thecodinglove.searchdata.model.Post
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DbPost(
+    @SerialName("title") val title: String,
+    @SerialName("url") val url: String,
+    @SerialName("image_url") val imageUrl: String,
+)
+
+fun Post.toPost() = DbPost(
+    title = title,
+    url = url,
+    imageUrl = imageUrl
+)

--- a/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/db/DbSearchSession.kt
+++ b/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/db/DbSearchSession.kt
@@ -1,7 +1,8 @@
-package com.gchristov.thecodinglove.searchdata.api
+package com.gchristov.thecodinglove.searchdata.db
 
 import com.gchristov.thecodinglove.kmpcommonkotlin.di.DiGraph
 import com.gchristov.thecodinglove.kmpcommonkotlin.di.inject
+import com.gchristov.thecodinglove.searchdata.model.SearchSession
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -11,40 +12,60 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 
 @Serializable
-data class ApiSearchSession(
+data class DbSearchSession(
     @SerialName("id") val id: String,
     @SerialName("query") val query: String,
     @SerialName("total_posts") val totalPosts: Int?,
     // Firebase doesn't like Map<Int, List<Int>> and throws ClassCastException
     @SerialName("search_history") val searchHistory: Map<String, List<Int>>,
-    @SerialName("current_post") val currentPost: ApiPost?,
-    @SerialName("preloaded_post") val preloadedPost: ApiPost?,
-    @SerialName("state") @Serializable(with = SessionStateSerializer::class) val state: ApiState
+    @SerialName("current_post") val currentPost: DbPost?,
+    @SerialName("preloaded_post") val preloadedPost: DbPost?,
+    @SerialName("state") @Serializable(with = SessionStateSerializer::class) val state: DbState
 ) {
     @Serializable
-    sealed class ApiState {
+    sealed class DbState {
         @Serializable
         @SerialName("searching")
-        object ApiSearching : ApiState()
+        object DbSearching : DbState()
     }
 }
 
 // There's currently an issue with Firebase serialization of sealed classes.
 // https://github.com/GitLiveApp/firebase-kotlin-sdk/issues/343
-private object SessionStateSerializer : KSerializer<ApiSearchSession.ApiState> {
+private object SessionStateSerializer : KSerializer<DbSearchSession.DbState> {
     private val jsonSerializer = DiGraph.inject<Json>()
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
-        serialName = "ApiSearchSession.ApiState",
+        serialName = "DbSearchSession.DbState",
         kind = PrimitiveKind.STRING
     )
 
-    override fun deserialize(decoder: Decoder): ApiSearchSession.ApiState =
+    override fun deserialize(decoder: Decoder): DbSearchSession.DbState =
         jsonSerializer.decodeFromString(decoder.decodeString())
 
     override fun serialize(
         encoder: Encoder,
-        value: ApiSearchSession.ApiState
+        value: DbSearchSession.DbState
     ) {
         encoder.encodeString(jsonSerializer.encodeToString(value))
     }
+}
+
+internal fun SearchSession.toSearchSession() = DbSearchSession(
+    id = id,
+    query = query,
+    totalPosts = totalPosts,
+    searchHistory = mutableMapOf<String, List<Int>>().apply {
+        searchHistory.keys.forEach { page ->
+            searchHistory[page]?.let { itemIndex ->
+                put(page.toString(), itemIndex)
+            }
+        }
+    },
+    currentPost = currentPost?.toPost(),
+    preloadedPost = preloadedPost?.toPost(),
+    state = state.toSearchSessionState()
+)
+
+private fun SearchSession.State.toSearchSessionState() = when (this) {
+    is SearchSession.State.Searching -> DbSearchSession.DbState.DbSearching
 }

--- a/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/model/Post.kt
+++ b/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/model/Post.kt
@@ -1,7 +1,7 @@
 package com.gchristov.thecodinglove.searchdata.model
 
 import com.gchristov.thecodinglove.htmlparsedata.HtmlPost
-import com.gchristov.thecodinglove.searchdata.api.ApiPost
+import com.gchristov.thecodinglove.searchdata.db.DbPost
 
 data class Post(
     val title: String,
@@ -15,7 +15,7 @@ internal fun HtmlPost.toPost() = Post(
     imageUrl = imageUrl
 )
 
-internal fun ApiPost.toPost() = Post(
+internal fun DbPost.toPost() = Post(
     title = title,
     url = url,
     imageUrl = imageUrl

--- a/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/model/SearchSession.kt
+++ b/backend/search-data/src/jsMain/kotlin/com/gchristov/thecodinglove/searchdata/model/SearchSession.kt
@@ -1,7 +1,6 @@
 package com.gchristov.thecodinglove.searchdata.model
 
-import com.gchristov.thecodinglove.searchdata.api.ApiSearchSession
-import com.gchristov.thecodinglove.searchdata.api.toPost
+import com.gchristov.thecodinglove.searchdata.db.DbSearchSession
 
 data class SearchSession(
     val id: String,
@@ -18,7 +17,7 @@ data class SearchSession(
     }
 }
 
-internal fun ApiSearchSession.toSearchSession() = SearchSession(
+internal fun DbSearchSession.toSearchSession() = SearchSession(
     id = id,
     query = query,
     totalPosts = totalPosts,
@@ -34,26 +33,6 @@ internal fun ApiSearchSession.toSearchSession() = SearchSession(
     state = state.toSearchSessionState()
 )
 
-private fun ApiSearchSession.ApiState.toSearchSessionState() = when (this) {
-    is ApiSearchSession.ApiState.ApiSearching -> SearchSession.State.Searching
-}
-
-internal fun SearchSession.toSearchSession() = ApiSearchSession(
-    id = id,
-    query = query,
-    totalPosts = totalPosts,
-    searchHistory = mutableMapOf<String, List<Int>>().apply {
-        searchHistory.keys.forEach { page ->
-            searchHistory[page]?.let { itemIndex ->
-                put(page.toString(), itemIndex)
-            }
-        }
-    },
-    currentPost = currentPost?.toPost(),
-    preloadedPost = preloadedPost?.toPost(),
-    state = state.toSearchSessionState()
-)
-
-private fun SearchSession.State.toSearchSessionState() = when (this) {
-    is SearchSession.State.Searching -> ApiSearchSession.ApiState.ApiSearching
+private fun DbSearchSession.DbState.toSearchSessionState() = when (this) {
+    is DbSearchSession.DbState.DbSearching -> SearchSession.State.Searching
 }

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
@@ -6,6 +6,7 @@ import com.gchristov.thecodinglove.searchdata.SearchRepository
 import com.gchristov.thecodinglove.searchdata.usecase.SearchUseCase
 import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import com.gchristov.thecodinglove.slackdata.usecase.*
+import dev.gitlive.firebase.firestore.FirebaseFirestore
 import io.ktor.client.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.datetime.Clock
@@ -24,7 +25,8 @@ object SlackDataModule : DiModule() {
             bindSingleton {
                 provideSlackRepository(
                     api = instance(),
-                    log = instance()
+                    log = instance(),
+                    firebaseFirestore = instance(),
                 )
             }
             bindProvider {
@@ -76,10 +78,12 @@ object SlackDataModule : DiModule() {
 
     private fun provideSlackRepository(
         api: SlackApi,
-        log: Logger
+        log: Logger,
+        firebaseFirestore: FirebaseFirestore,
     ): SlackRepository = RealSlackRepository(
         apiService = api,
-        log = log
+        log = log,
+        firebaseFirestore = firebaseFirestore
     )
 
     private fun provideSlackVerifyRequestUseCase(

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
@@ -57,7 +57,7 @@ object SlackDataModule : DiModule() {
                 )
             }
             bindProvider {
-                provideSlackAuthUserUseCase(
+                provideSlackAuthUseCase(
                     slackConfig = instance(),
                     log = instance(),
                     slackRepository = instance(),
@@ -129,11 +129,11 @@ object SlackDataModule : DiModule() {
         slackRepository = slackRepository
     )
 
-    private fun provideSlackAuthUserUseCase(
+    private fun provideSlackAuthUseCase(
         slackConfig: SlackConfig,
         log: Logger,
         slackRepository: SlackRepository,
-    ): SlackAuthUserUseCase = RealSlackAuthUserUseCase(
+    ): SlackAuthUseCase = RealSlackAuthUseCase(
         dispatcher = Dispatchers.Default,
         slackConfig = slackConfig,
         log = log,

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackRepository.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackRepository.kt
@@ -5,6 +5,8 @@ import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackAuthResponse
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackMessage
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackPostMessageResponse
+import com.gchristov.thecodinglove.slackdata.domain.SlackAuthToken
+import com.gchristov.thecodinglove.slackdata.domain.toAuthToken
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 
@@ -13,7 +15,7 @@ interface SlackRepository {
         code: String,
         clientId: String,
         clientSecret: String,
-    ): Either<Throwable, Unit>
+    ): Either<Throwable, SlackAuthToken>
 
     suspend fun replyWithMessage(
         responseUrl: String,
@@ -41,7 +43,7 @@ internal class RealSlackRepository(
             clientSecret = clientSecret
         ).body()
         if (slackResponse.ok) {
-            Either.Right(Unit)
+            Either.Right(slackResponse.toAuthToken())
         } else {
             throw Exception(slackResponse.error)
         }

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackAuth.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackAuth.kt
@@ -7,4 +7,19 @@ import kotlinx.serialization.Serializable
 data class ApiSlackAuthResponse(
     @SerialName("ok") val ok: Boolean,
     @SerialName("error") val error: String?,
-)
+    @SerialName("authed_user") val authedUser: ApiAuthedUser?,
+    @SerialName("team") val team: ApiTeam?,
+) {
+    @Serializable
+    data class ApiAuthedUser(
+        @SerialName("id") val id: String,
+        @SerialName("scope") val scope: String,
+        @SerialName("access_token") val accessToken: String,
+    )
+
+    @Serializable
+    data class ApiTeam(
+        @SerialName("id") val id: String,
+        @SerialName("name") val name: String,
+    )
+}

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/db/DbSlackAuthToken.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/db/DbSlackAuthToken.kt
@@ -1,0 +1,22 @@
+package com.gchristov.thecodinglove.slackdata.db
+
+import com.gchristov.thecodinglove.slackdata.domain.SlackAuthToken
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DbSlackAuthToken(
+    @SerialName("user_id") val userId: String,
+    @SerialName("scope") val scope: String,
+    @SerialName("token") val token: String,
+    @SerialName("team_id") val teamId: String,
+    @SerialName("team_name") val teamName: String,
+)
+
+internal fun SlackAuthToken.toAuthToken() = DbSlackAuthToken(
+    userId = userId,
+    scope = scope,
+    token = token,
+    teamId = teamId,
+    teamName = teamName,
+)

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuthToken.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuthToken.kt
@@ -1,0 +1,19 @@
+package com.gchristov.thecodinglove.slackdata.domain
+
+import com.gchristov.thecodinglove.slackdata.api.ApiSlackAuthResponse
+
+data class SlackAuthToken(
+    val userId: String,
+    val scope: String,
+    val token: String,
+    val teamId: String,
+    val teamName: String,
+)
+
+internal fun ApiSlackAuthResponse.toAuthToken() = SlackAuthToken(
+    userId = requireNotNull(authedUser).id,
+    scope = requireNotNull(authedUser).scope,
+    token = requireNotNull(authedUser).accessToken,
+    teamId = requireNotNull(team).id,
+    teamName = requireNotNull(team).name,
+)

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuthToken.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuthToken.kt
@@ -1,6 +1,7 @@
 package com.gchristov.thecodinglove.slackdata.domain
 
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackAuthResponse
+import com.gchristov.thecodinglove.slackdata.db.DbSlackAuthToken
 
 data class SlackAuthToken(
     val userId: String,
@@ -16,4 +17,12 @@ internal fun ApiSlackAuthResponse.toAuthToken() = SlackAuthToken(
     token = requireNotNull(authedUser).accessToken,
     teamId = requireNotNull(team).id,
     teamName = requireNotNull(team).name,
+)
+
+internal fun DbSlackAuthToken.toAuthToken() = SlackAuthToken(
+    userId = userId,
+    scope = scope,
+    token = token,
+    teamId = teamId,
+    teamName = teamName,
 )

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt
@@ -8,7 +8,7 @@ import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
-interface SlackAuthUserUseCase {
+interface SlackAuthUseCase {
     suspend operator fun invoke(
         code: String?,
         searchSessionId: String?,
@@ -20,32 +20,32 @@ interface SlackAuthUserUseCase {
     }
 }
 
-class RealSlackAuthUserUseCase(
+class RealSlackAuthUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val slackConfig: SlackConfig,
     private val log: Logger,
     private val slackRepository: SlackRepository,
-) : SlackAuthUserUseCase {
+) : SlackAuthUseCase {
     override suspend fun invoke(
         code: String?,
         searchSessionId: String?
-    ): Either<SlackAuthUserUseCase.Error, Unit> = withContext(dispatcher) {
+    ): Either<SlackAuthUseCase.Error, Unit> = withContext(dispatcher) {
         log.d("Processing Slack user auth request: code=$code, searchSessionId=$searchSessionId")
         if (code.isNullOrEmpty()) {
             log.d("Auth cancelled")
-            Either.Left(SlackAuthUserUseCase.Error.Cancelled)
+            Either.Left(SlackAuthUseCase.Error.Cancelled)
         } else {
             slackRepository.authUser(
                 code = code,
                 clientId = slackConfig.clientId,
                 clientSecret = slackConfig.clientSecret
             )
-                .mapLeft { SlackAuthUserUseCase.Error.Other(it.message) }
+                .mapLeft { SlackAuthUseCase.Error.Other(it.message) }
                 .flatMap { authResponse ->
                     log.d("Persisting user token")
                     slackRepository
                         .saveAuthToken(authResponse)
-                        .mapLeft { SlackAuthUserUseCase.Error.Other(it.message) }
+                        .mapLeft { SlackAuthUseCase.Error.Other(it.message) }
                 }
         }
     }

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUserUseCase.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUserUseCase.kt
@@ -43,9 +43,9 @@ class RealSlackAuthUserUseCase(
                 .mapLeft { SlackAuthUserUseCase.Error.Other(it.message) }
                 .flatMap { authResponse ->
                     log.d("Persisting user token")
-                    // TODO: Persist user token
-                    println(authResponse)
-                    Either.Right(Unit)
+                    slackRepository
+                        .saveAuthToken(authResponse)
+                        .mapLeft { SlackAuthUserUseCase.Error.Other(it.message) }
                 }
         }
     }

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
@@ -68,7 +68,7 @@ object SlackModule : DiModule() {
                     apiServiceRegister = instance(),
                     jsonSerializer = instance(),
                     log = instance(),
-                    slackAuthUserUseCase = instance(),
+                    slackAuthUseCase = instance(),
                 )
             }
         }
@@ -140,11 +140,11 @@ object SlackModule : DiModule() {
         apiServiceRegister: ApiServiceRegister,
         jsonSerializer: Json,
         log: Logger,
-        slackAuthUserUseCase: SlackAuthUserUseCase,
+        slackAuthUseCase: SlackAuthUseCase,
     ): SlackAuthApiService = SlackAuthApiService(
         apiServiceRegister = apiServiceRegister,
         jsonSerializer = jsonSerializer,
         log = log,
-        slackAuthUserUseCase = slackAuthUserUseCase,
+        slackAuthUseCase = slackAuthUseCase,
     )
 }

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
@@ -8,14 +8,14 @@ import com.gchristov.thecodinglove.commonservicedata.api.ApiRequest
 import com.gchristov.thecodinglove.commonservicedata.api.ApiResponse
 import com.gchristov.thecodinglove.commonservicedata.api.ApiServiceRegister
 import com.gchristov.thecodinglove.commonservicedata.exports
-import com.gchristov.thecodinglove.slackdata.usecase.SlackAuthUserUseCase
+import com.gchristov.thecodinglove.slackdata.usecase.SlackAuthUseCase
 import kotlinx.serialization.json.Json
 
 class SlackAuthApiService(
     apiServiceRegister: ApiServiceRegister,
     jsonSerializer: Json,
     private val log: Logger,
-    private val slackAuthUserUseCase: SlackAuthUserUseCase,
+    private val slackAuthUseCase: SlackAuthUseCase,
 ) : ApiService(
     apiServiceRegister = apiServiceRegister,
     jsonSerializer = jsonSerializer,
@@ -31,7 +31,7 @@ class SlackAuthApiService(
     ): Either<Throwable, Unit> {
         val code: String? = request.query["code"]
         val searchSessionId: String? = request.query["state"]
-        return slackAuthUserUseCase(
+        return slackAuthUseCase(
             code = code,
             searchSessionId = searchSessionId,
         ).flatMap {
@@ -44,11 +44,11 @@ class SlackAuthApiService(
         error: Throwable,
         response: ApiResponse
     ): Either<Throwable, Unit> = when (error) {
-        is SlackAuthUserUseCase.Error.Cancelled -> {
+        is SlackAuthUseCase.Error.Cancelled -> {
             response.redirect("/")
             Either.Right(Unit)
         }
-        is SlackAuthUserUseCase.Error.Other -> {
+        is SlackAuthUseCase.Error.Other -> {
             response.redirect("/slack/auth/error")
             Either.Right(Unit)
         }

--- a/client/appWeb/appWeb/src/jsMain/resources/slack/auth/success/index.html
+++ b/client/appWeb/appWeb/src/jsMain/resources/slack/auth/success/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Authorization Error</title>
+    <title>Authorization Success</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Fav + shortcut icons -->
     <link href="/static/images/favicon.png" rel="shortcut icon" type="image/x-icon" />


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR persists the Slack authentication token in Firestore.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
