### PR TITLE
Send Slack message using auth token

### DIFF
--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
@@ -55,6 +55,7 @@ object SlackDataModule : DiModule() {
                     log = instance(),
                     searchRepository = instance(),
                     slackRepository = instance(),
+                    slackConfig = instance(),
                 )
             }
             bindProvider {
@@ -129,11 +130,13 @@ object SlackDataModule : DiModule() {
         log: Logger,
         searchRepository: SearchRepository,
         slackRepository: SlackRepository,
+        slackConfig: SlackConfig,
     ): SlackSendSearchUseCase = RealSlackSendSearchUseCase(
         dispatcher = Dispatchers.Default,
         log = log,
         searchRepository = searchRepository,
-        slackRepository = slackRepository
+        slackRepository = slackRepository,
+        slackConfig = slackConfig,
     )
 
     private fun provideSlackAuthUseCase(

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackMessage.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackMessage.kt
@@ -141,6 +141,45 @@ object ApiSlackMessageFactory {
         ),
     )
 
+    fun authMessage(
+        searchSessionId: String,
+        teamId: String,
+        clientId: String
+    ) = ApiSlackMessage(
+        text = null,
+        userId = null,
+        channelId = null,
+        responseType = ApiSlackMessageResponseType.EPHEMERAL.apiValue,
+        responseUrl = null,
+        teamId = null,
+        replaceOriginal = true,
+        deleteOriginal = false,
+        attachments = listOf(
+            attachment(
+                text = "The Coding Love GIFs does not have permission to send messages on your behalf yet. Press Authorize and Send below to allow this.",
+                footer = "We'll never post without your permission.",
+                actions = listOf(
+                    ApiSlackMessage.ApiAttachment.ApiAction(
+                        name = ApiSlackActionName.SEND.apiValue,
+                        text = "Authorize and Send",
+                        type = ButtonType,
+                        value = searchSessionId,
+                        url = "https://slack.com/oauth/v2/authorize?client_id=$clientId&user_scope=chat:write&team=$teamId&state=$searchSessionId",
+                        style = PrimaryButtonStyle,
+                    ),
+                    ApiSlackMessage.ApiAttachment.ApiAction(
+                        name = ApiSlackActionName.CANCEL.apiValue,
+                        text = "Cancel",
+                        type = ButtonType,
+                        value = searchSessionId,
+                        url = null,
+                        style = null,
+                    )
+                ),
+            )
+        ),
+    )
+
     fun searchPostMessage(
         searchQuery: String,
         attachmentTitle: String,
@@ -167,16 +206,18 @@ object ApiSlackMessageFactory {
     )
 
     private fun attachment(
-        title: String,
-        url: String,
-        imageUrl: String,
+        title: String? = null,
+        text: String? = null,
+        url: String? = null,
+        footer: String? = "Posted using /codinglove",
+        imageUrl: String? = null,
         actions: List<ApiSlackMessage.ApiAttachment.ApiAction>,
     ) = ApiSlackMessage.ApiAttachment(
         title = title,
         titleLink = url,
-        text = null,
+        text = text,
         imageUrl = imageUrl,
-        footer = "Posted using /codinglove",
+        footer = footer,
         callbackId = uuid4().toString(),
         color = "#1e1e1e",
         actions = actions,

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackSendSearchUseCase.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackSendSearchUseCase.kt
@@ -6,11 +6,14 @@ import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.searchdata.SearchRepository
 import com.gchristov.thecodinglove.slackdata.SlackRepository
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackMessageFactory
+import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
 interface SlackSendSearchUseCase {
     suspend operator fun invoke(
+        userId: String,
+        teamId: String,
         channelId: String,
         responseUrl: String,
         searchSessionId: String,
@@ -22,14 +25,65 @@ class RealSlackSendSearchUseCase(
     private val log: Logger,
     private val searchRepository: SearchRepository,
     private val slackRepository: SlackRepository,
+    private val slackConfig: SlackConfig,
 ) : SlackSendSearchUseCase {
     override suspend operator fun invoke(
+        userId: String,
+        teamId: String,
         channelId: String,
         responseUrl: String,
-        searchSessionId: String,
+        searchSessionId: String
     ): Either<Throwable, Unit> = withContext(dispatcher) {
+        log.d("Checking auth token before sending message: userId=$userId")
+        slackRepository.getAuthToken(tokenId = userId)
+            .fold(
+                ifLeft = {
+                    log.e(it) { it.message ?: "Error fetching user token" }
+                    authenticate(
+                        userId = userId,
+                        responseUrl = responseUrl,
+                        searchSessionId = searchSessionId,
+                        teamId = teamId,
+                        clientId = slackConfig.clientId,
+                    )
+                },
+                ifRight = {
+                    sendResult(
+                        authToken = it.token,
+                        channelId = channelId,
+                        responseUrl = responseUrl,
+                        searchSessionId = searchSessionId
+                    )
+                }
+            )
+    }
+
+    private suspend fun authenticate(
+        userId: String,
+        responseUrl: String,
+        searchSessionId: String,
+        teamId: String,
+        clientId: String,
+    ): Either<Throwable, Unit> {
+        log.d("Asking user to authenticate: userId=$userId")
+        return slackRepository.replyWithMessage(
+            responseUrl = responseUrl,
+            message = ApiSlackMessageFactory.authMessage(
+                searchSessionId = searchSessionId,
+                teamId = teamId,
+                clientId = clientId,
+            )
+        )
+    }
+
+    private suspend fun sendResult(
+        authToken: String,
+        channelId: String,
+        responseUrl: String,
+        searchSessionId: String
+    ): Either<Throwable, Unit> {
         log.d("Obtaining search session: searchSessionId=$searchSessionId")
-        searchRepository.getSearchSession(searchSessionId)
+        return searchRepository.getSearchSession(searchSessionId)
             .flatMap { searchSession ->
                 log.d("Cancelling previous Slack message: responseUrl=$responseUrl")
                 slackRepository.replyWithMessage(
@@ -38,7 +92,7 @@ class RealSlackSendSearchUseCase(
                 ).flatMap {
                     log.d("Posting search result: searchSessionId=$searchSessionId")
                     slackRepository.postMessage(
-                        authToken = "TOKEN",
+                        authToken = authToken,
                         message = ApiSlackMessageFactory.searchPostMessage(
                             searchQuery = searchSession.query,
                             attachmentTitle = searchSession.currentPost!!.title,

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
@@ -35,6 +35,7 @@ class SlackAuthApiService(
             code = code,
             searchSessionId = searchSessionId,
         ).flatMap {
+            // TODO: CHeck for sessions and resume send action
             response.redirect("/slack/auth/success")
             Either.Right(Unit)
         }

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/interactivity/SlackInteractivityPubSubService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/interactivity/SlackInteractivityPubSubService.kt
@@ -53,6 +53,8 @@ class SlackInteractivityPubSubService(
         val cancelAction = cancelAction()
         return when {
             sendAction != null -> slackSendSearchUseCase.invoke(
+                userId = user.id,
+                teamId = team.id,
                 channelId = channel.id,
                 responseUrl = responseUrl,
                 searchSessionId = sendAction.value


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR adds checks for user tokens when the `Send` button is pressed. If a token exists, we use it to send the message on the user's behalf. Otherwise, we ask the user to authenticate.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
