### PR TITLE
Automatically send pending Slack search after successful auth

### DIFF
--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/SlackDataModule.kt
@@ -8,9 +8,9 @@ import com.gchristov.thecodinglove.searchdata.usecase.SearchUseCase
 import com.gchristov.thecodinglove.slackdata.domain.SlackConfig
 import com.gchristov.thecodinglove.slackdata.usecase.*
 import dev.gitlive.firebase.firestore.FirebaseFirestore
-import io.ktor.client.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.datetime.Clock
+import kotlinx.serialization.json.Json
 import org.kodein.di.DI
 import org.kodein.di.bindProvider
 import org.kodein.di.bindSingleton
@@ -56,6 +56,7 @@ object SlackDataModule : DiModule() {
                     searchRepository = instance(),
                     slackRepository = instance(),
                     slackConfig = instance(),
+                    jsonSerializer = instance(),
                 )
             }
             bindProvider {
@@ -131,12 +132,14 @@ object SlackDataModule : DiModule() {
         searchRepository: SearchRepository,
         slackRepository: SlackRepository,
         slackConfig: SlackConfig,
+        jsonSerializer: Json,
     ): SlackSendSearchUseCase = RealSlackSendSearchUseCase(
         dispatcher = Dispatchers.Default,
         log = log,
         searchRepository = searchRepository,
         slackRepository = slackRepository,
         slackConfig = slackConfig,
+        jsonSerializer = jsonSerializer,
     )
 
     private fun provideSlackAuthUseCase(

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackAuth.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackAuth.kt
@@ -23,3 +23,12 @@ data class ApiSlackAuthResponse(
         @SerialName("name") val name: String,
     )
 }
+
+@Serializable
+data class ApiSlackAuthState(
+    @SerialName("search_session_id") val searchSessionId: String,
+    @SerialName("channel_id") val channelId: String,
+    @SerialName("team_id") val teamId: String,
+    @SerialName("user_id") val userId: String,
+    @SerialName("response_url") val responseUrl: String,
+)

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackMessage.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackMessage.kt
@@ -51,10 +51,11 @@ data class ApiSlackMessage(
     }
 }
 
-enum class ApiSlackActionName(val apiValue: String) {
-    SEND("send"),
-    SHUFFLE("shuffle"),
-    CANCEL("cancel"),
+enum class ApiSlackActionName(val apiValue: String, val text: String) {
+    AUTH_SEND(apiValue = "auth_send", text = "Authorize and Send"),
+    SEND(apiValue = "send", text = "Send"),
+    SHUFFLE(apiValue = "shuffle", text = "Shuffle"),
+    CANCEL(apiValue = "cancel", text = "Cancel"),
 }
 
 private enum class ApiSlackMessageResponseType(val apiValue: String) {
@@ -63,8 +64,8 @@ private enum class ApiSlackMessageResponseType(val apiValue: String) {
 }
 
 object ApiSlackMessageFactory {
-    private const val ButtonType = "button"
-    private const val PrimaryButtonStyle = "primary"
+    private const val ActionTypeButton = "button"
+    private const val ActionStylePrimary = "primary"
 
     fun processingMessage() = ApiSlackMessage(
         text = "🔎 Hang tight, we're finding your GIF...",
@@ -114,24 +115,24 @@ object ApiSlackMessageFactory {
                 actions = listOf(
                     ApiSlackMessage.ApiAttachment.ApiAction(
                         name = ApiSlackActionName.SEND.apiValue,
-                        text = "Send",
-                        type = ButtonType,
+                        text = ApiSlackActionName.SEND.text,
+                        type = ActionTypeButton,
                         value = searchSessionId,
                         url = null,
-                        style = PrimaryButtonStyle,
+                        style = ActionStylePrimary,
                     ),
                     ApiSlackMessage.ApiAttachment.ApiAction(
                         name = ApiSlackActionName.SHUFFLE.apiValue,
-                        text = "Shuffle",
-                        type = ButtonType,
+                        text = ApiSlackActionName.SHUFFLE.text,
+                        type = ActionTypeButton,
                         value = searchSessionId,
                         url = null,
                         style = null,
                     ),
                     ApiSlackMessage.ApiAttachment.ApiAction(
                         name = ApiSlackActionName.CANCEL.apiValue,
-                        text = "Cancel",
-                        type = ButtonType,
+                        text = ApiSlackActionName.CANCEL.text,
+                        type = ActionTypeButton,
                         value = searchSessionId,
                         url = null,
                         style = null,
@@ -144,7 +145,8 @@ object ApiSlackMessageFactory {
     fun authMessage(
         searchSessionId: String,
         teamId: String,
-        clientId: String
+        clientId: String,
+        state: String,
     ) = ApiSlackMessage(
         text = null,
         userId = null,
@@ -160,17 +162,17 @@ object ApiSlackMessageFactory {
                 footer = "We'll never post without your permission.",
                 actions = listOf(
                     ApiSlackMessage.ApiAttachment.ApiAction(
-                        name = ApiSlackActionName.SEND.apiValue,
-                        text = "Authorize and Send",
-                        type = ButtonType,
-                        value = searchSessionId,
-                        url = "https://slack.com/oauth/v2/authorize?client_id=$clientId&user_scope=chat:write&team=$teamId&state=$searchSessionId",
-                        style = PrimaryButtonStyle,
+                        name = ApiSlackActionName.AUTH_SEND.apiValue,
+                        text = ApiSlackActionName.AUTH_SEND.text,
+                        type = ActionTypeButton,
+                        value = null,
+                        url = "https://slack.com/oauth/v2/authorize?client_id=$clientId&user_scope=chat:write&team=$teamId&state=$state",
+                        style = ActionStylePrimary,
                     ),
                     ApiSlackMessage.ApiAttachment.ApiAction(
                         name = ApiSlackActionName.CANCEL.apiValue,
-                        text = "Cancel",
-                        type = ButtonType,
+                        text = ApiSlackActionName.CANCEL.text,
+                        type = ActionTypeButton,
                         value = searchSessionId,
                         url = null,
                         style = null,

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuth.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuth.kt
@@ -1,6 +1,7 @@
 package com.gchristov.thecodinglove.slackdata.domain
 
 import com.gchristov.thecodinglove.slackdata.api.ApiSlackAuthResponse
+import com.gchristov.thecodinglove.slackdata.api.ApiSlackAuthState
 import com.gchristov.thecodinglove.slackdata.db.DbSlackAuthToken
 
 data class SlackAuthToken(
@@ -9,6 +10,14 @@ data class SlackAuthToken(
     val token: String,
     val teamId: String,
     val teamName: String,
+)
+
+data class SlackAuthState(
+    val searchSessionId: String,
+    val channelId: String,
+    val teamId: String,
+    val userId: String,
+    val responseUrl: String,
 )
 
 internal fun ApiSlackAuthResponse.toAuthToken() = SlackAuthToken(
@@ -25,4 +34,12 @@ internal fun DbSlackAuthToken.toAuthToken() = SlackAuthToken(
     token = token,
     teamId = teamId,
     teamName = teamName,
+)
+
+fun ApiSlackAuthState.toAuthState() = SlackAuthState(
+    searchSessionId = searchSessionId,
+    channelId = channelId,
+    teamId = teamId,
+    userId = userId,
+    responseUrl = responseUrl,
 )

--- a/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt
+++ b/backend/slack-data/src/jsMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt
@@ -9,10 +9,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
 interface SlackAuthUseCase {
-    suspend operator fun invoke(
-        code: String?,
-        searchSessionId: String?,
-    ): Either<Error, Unit>
+    suspend operator fun invoke(code: String?): Either<Error, Unit>
 
     sealed class Error(message: String? = null) : Throwable(message) {
         object Cancelled : Error()
@@ -26,11 +23,8 @@ class RealSlackAuthUseCase(
     private val log: Logger,
     private val slackRepository: SlackRepository,
 ) : SlackAuthUseCase {
-    override suspend fun invoke(
-        code: String?,
-        searchSessionId: String?
-    ): Either<SlackAuthUseCase.Error, Unit> = withContext(dispatcher) {
-        log.d("Processing Slack user auth request: code=$code, searchSessionId=$searchSessionId")
+    override suspend fun invoke(code: String?): Either<SlackAuthUseCase.Error, Unit> = withContext(dispatcher) {
+        log.d("Processing Slack user auth request: code=$code")
         if (code.isNullOrEmpty()) {
             log.d("Auth cancelled")
             Either.Left(SlackAuthUseCase.Error.Cancelled)

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/SlackModule.kt
@@ -70,6 +70,7 @@ object SlackModule : DiModule() {
                     jsonSerializer = instance(),
                     log = instance(),
                     slackAuthUseCase = instance(),
+                    slackSendSearchUseCase = instance(),
                 )
             }
             bindSingleton {
@@ -152,11 +153,13 @@ object SlackModule : DiModule() {
         jsonSerializer: Json,
         log: Logger,
         slackAuthUseCase: SlackAuthUseCase,
+        slackSendSearchUseCase: SlackSendSearchUseCase,
     ): SlackAuthApiService = SlackAuthApiService(
         apiServiceRegister = apiServiceRegister,
         jsonSerializer = jsonSerializer,
         log = log,
         slackAuthUseCase = slackAuthUseCase,
+        slackSendSearchUseCase = slackSendSearchUseCase,
     )
 
     private fun provideSlackEventApiService(

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
@@ -8,14 +8,20 @@ import com.gchristov.thecodinglove.commonservicedata.api.ApiRequest
 import com.gchristov.thecodinglove.commonservicedata.api.ApiResponse
 import com.gchristov.thecodinglove.commonservicedata.api.ApiServiceRegister
 import com.gchristov.thecodinglove.commonservicedata.exports
+import com.gchristov.thecodinglove.slackdata.api.ApiSlackAuthState
+import com.gchristov.thecodinglove.slackdata.domain.toAuthState
 import com.gchristov.thecodinglove.slackdata.usecase.SlackAuthUseCase
+import com.gchristov.thecodinglove.slackdata.usecase.SlackSendSearchUseCase
+import io.ktor.util.*
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class SlackAuthApiService(
     apiServiceRegister: ApiServiceRegister,
-    jsonSerializer: Json,
-    log: Logger,
+    private val jsonSerializer: Json,
+    private val log: Logger,
     private val slackAuthUseCase: SlackAuthUseCase,
+    private val slackSendSearchUseCase: SlackSendSearchUseCase,
 ) : ApiService(
     apiServiceRegister = apiServiceRegister,
     jsonSerializer = jsonSerializer,
@@ -30,14 +36,10 @@ class SlackAuthApiService(
         response: ApiResponse
     ): Either<Throwable, Unit> {
         val code: String? = request.query["code"]
-        val searchSessionId: String? = request.query["state"]
-        return slackAuthUseCase(
-            code = code,
-            searchSessionId = searchSessionId,
-        ).flatMap {
-            // TODO: CHeck for sessions and resume send action
+        val state: String? = request.query["state"]
+        return slackAuthUseCase(code = code).flatMap {
             response.redirect("/slack/auth/success")
-            Either.Right(Unit)
+            state?.let { handleAuthState(it) } ?: Either.Right(Unit)
         }
     }
 
@@ -49,10 +51,31 @@ class SlackAuthApiService(
             response.redirect("/")
             Either.Right(Unit)
         }
+
         is SlackAuthUseCase.Error.Other -> {
             response.redirect("/slack/auth/error")
             Either.Right(Unit)
         }
+
         else -> super.handleError(error, response)
+    }
+
+    private suspend fun handleAuthState(state: String) = try {
+        val base64Decoded = state.decodeBase64String()
+        log.d("Decoded Base64 auth state: decoded=$base64Decoded")
+        val authState = jsonSerializer
+            .decodeFromString<ApiSlackAuthState>(base64Decoded)
+            .toAuthState()
+        log.d("Parsed Base64 auth state: parsed=$authState")
+        slackSendSearchUseCase.invoke(
+            userId = authState.userId,
+            teamId = authState.teamId,
+            channelId = authState.channelId,
+            responseUrl = authState.responseUrl,
+            searchSessionId = authState.searchSessionId,
+        )
+    } catch (error: Throwable) {
+        log.e(error) { error.message ?: "Error during auth state handling" }
+        Either.Left(error)
     }
 }

--- a/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
+++ b/backend/slack/src/jsMain/kotlin/com/gchristov/thecodinglove/slack/auth/SlackAuthApiService.kt
@@ -38,8 +38,11 @@ class SlackAuthApiService(
         val code: String? = request.query["code"]
         val state: String? = request.query["state"]
         return slackAuthUseCase(code = code).flatMap {
-            response.redirect("/slack/auth/success")
-            state?.let { handleAuthState(it) } ?: Either.Right(Unit)
+            val stateResult = state?.let { handleAuthState(it) } ?: Either.Right(Unit)
+            stateResult.flatMap {
+                response.redirect("/slack/auth/success")
+                Either.Right(Unit)
+            }
         }
     }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,6 @@
-# Builds and runs the API project locally with the Firebase Emulator
+# Builds and runs the API project locally with some simulators and tunnels for external (eg Slack) access
 set -e
 echo "🛠 Building..." && sh ./scripts/build.sh
-echo "🏁 Starting local emulators..." && ssh -R 80:localhost:5000 serveo.net & ssh -R 80:localhost:5001 serveo.net & firebase emulators:start
+echo "🏁 Starting local website tunnel..." && (ssh -tt -R 80:localhost:5000 serveo.net &) && sleep 1
+echo "🏁 Starting local API tunnel..." && (ssh -tt -R 80:localhost:5001 serveo.net &) && sleep 1
+echo "🏁 Starting local Firebase emulators..." && firebase emulators:start


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR implements the "Authorize and Send" functionality for Slack. This is done by encoding the required session `state` into a Base64 string and passing it through to the OAuth flow. After the OAuth flow finishes, the `state` is sent back to the app and is used to find the pending search session and send it on the user's behalf.

## Demo

https://github.com/gchristov/thecodinglove-kmp/assets/7644787/03a10b2f-712d-45bf-97af-8633fe43bbf9

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
