### PR TITLE
Enable NodeJS source maps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY /build/bin/. ./bin/
 # Step 2: Run binaries
 FROM npm AS run
 WORKDIR ./bin/
-CMD [ "node", "thecodinglove-kmp-appBackend.js" ]
+CMD exec node --enable-source-maps thecodinglove-kmp-appBackend.js


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR enables NodeJS source maps to allow exception stack traces to point to the original Kotlin file as well as to the generated Javascript files.

## How is this change tested?

Manually 👇 

```
// Before
[SlackAuthHttpHandler] Error handling request

Cancelled
   at Cancelled_getInstance (/app/bin/thecodinglove-kmp-appBackend.js:70582:7)
   at RealSlackAuthUseCase$invoke$slambda.protoOf.qh (/app/bin/thecodinglove-kmp-appBackend.js:70645:38)
   at RealSlackAuthUseCase$invoke$slambda.protoOf.n5e (/app/bin/thecodinglove-kmp-appBackend.js:70628:16)
   at l (/app/bin/thecodinglove-kmp-appBackend.js:70749:16)
   at startUndispatchedOrReturn (/app/bin/thecodinglove-kmp-appBackend.js:21187:47)
   at withContext (/app/bin/thecodinglove-kmp-appBackend.js:15422:21)
   at RealSlackAuthUseCase.protoOf.v5d (/app/bin/thecodinglove-kmp-appBackend.js:70762:16)
   at $handleHttpRequestAsyncCOROUTINE$0.protoOf.qh (/app/bin/thecodinglove-kmp-appBackend.js:73679:46)
   at SlackAuthHttpHandler.protoOf.g5m (/app/bin/thecodinglove-kmp-appBackend.js:73847:16)
   at BaseHttpHandler$handleHttpRequest$slambda.protoOf.qh (/app/bin/thecodinglove-kmp-appBackend.js:71798:40)
```
```
// After
[SlackAuthHttpHandler] Error handling request

Cancelled
   at Cancelled_getInstance (/app/bin/thecodinglove-kmp-appBackend.js:70582:7)
   at RealSlackAuthUseCase$invoke$slambda.protoOf.qh (/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt:33:20)
   at RealSlackAuthUseCase$invoke$slambda.protoOf.n5e (/app/bin/thecodinglove-kmp-appBackend.js:70628:16)
   at l (/app/bin/thecodinglove-kmp-appBackend.js:70749:16)
   at startUndispatchedOrReturn (/backend/appBackend/build/compileSync/js/main/productionLibrary/kotlin/src/kotlin/coroutines_13/IntrinsicsJs.kt:99:43)
   at withContext (/opt/teamcity-agent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/js/src/CoroutineContext.kt:61:5819)
   at RealSlackAuthUseCase.protoOf.v5d (/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt:29:88)
   at $handleHttpRequestAsyncCOROUTINE$0.protoOf.qh (/backend/slack/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/SlackAuthHttpHandler.kt:46:16)
   at SlackAuthHttpHandler.protoOf.g5m (/app/bin/thecodinglove-kmp-appBackend.js:73847:16)
   at BaseHttpHandler$handleHttpRequest$slambda.protoOf.qh (/backend/common-service/src/commonMain/kotlin/com/gchristov/thecodinglove/commonservice/BaseHttpHandler.kt:55:17)
```

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
