### PR TITLE
Log exhausted search query

### DIFF
--- a/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/domain/SearchError.kt
+++ b/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/domain/SearchError.kt
@@ -1,12 +1,16 @@
 package com.gchristov.thecodinglove.searchdata.domain
 
 sealed class SearchError(override val message: String? = null) : Throwable(message) {
+    abstract val additionalInfo: String?
     data class Empty(
-        val additionalInfo: String? = null
+        override val additionalInfo: String? = null
     ) : SearchError("No results found${additionalInfo?.let { ": $it" } ?: ""}")
 
-    object Exhausted : SearchError("Results exhausted")
+    data class Exhausted(
+        override val additionalInfo: String? = null
+    ) : SearchError("Results exhausted${additionalInfo?.let { ": $it" } ?: ""}")
+
     data class SessionNotFound(
-        val additionalInfo: String? = null
+        override val additionalInfo: String? = null
     ) : SearchError("Session not found${additionalInfo?.let { ": $it" } ?: ""}")
 }

--- a/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/usecase/SearchWithHistoryUseCase.kt
+++ b/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/usecase/SearchWithHistoryUseCase.kt
@@ -50,7 +50,7 @@ class RealSearchWithHistoryUseCase(
                     resultsPerPage = searchConfig.postsPerPage,
                     exclusions = searchHistory.getExcludedPages()
                 )
-                    .mapLeft { it.toSearchError() }
+                    .mapLeft { it.toSearchError(query) }
                     .flatMap { postPage ->
                         // Get all posts on the random page
                         searchRepository.search(
@@ -67,7 +67,7 @@ class RealSearchWithHistoryUseCase(
                                     posts = searchResults,
                                     exclusions = searchHistory.getExcludedPostIndexes(postPage)
                                 )
-                                    .mapLeft { it.toSearchError() }
+                                    .mapLeft { it.toSearchError(query) }
                                     .map { postIndexOnPage ->
                                         SearchWithHistoryUseCase.Result(
                                             query = query,
@@ -84,7 +84,7 @@ class RealSearchWithHistoryUseCase(
     }
 }
 
-private fun RangeError.toSearchError() = when (this) {
+private fun RangeError.toSearchError(query: String) = when (this) {
     is RangeError.Empty -> SearchError.Empty(additionalInfo = "could not randomize")
-    is RangeError.Exhausted -> SearchError.Exhausted
+    is RangeError.Exhausted -> SearchError.Exhausted(additionalInfo = "query=$query")
 }

--- a/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -76,7 +76,7 @@ class RealPreloadSearchResultUseCaseTest {
         )
 
         return runBlockingTest(
-            singleSearchWithHistoryInvocationResult = Either.Left(SearchError.Exhausted),
+            singleSearchWithHistoryInvocationResult = Either.Left(SearchError.Exhausted(additionalInfo = "test")),
             searchSession = searchSession,
         ) { useCase, searchRepository, searchWithHistoryUseCase ->
             val actualResult = useCase.invoke(searchSessionId = TestSearchSessionId)
@@ -93,7 +93,7 @@ class RealPreloadSearchResultUseCaseTest {
                 )
             )
             assertEquals(
-                expected = Either.Left(SearchError.Exhausted),
+                expected = Either.Left(SearchError.Exhausted(additionalInfo = "test")),
                 actual = actualResult,
             )
         }

--- a/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealSearchUseCaseTest.kt
+++ b/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealSearchUseCaseTest.kt
@@ -125,7 +125,7 @@ class RealSearchUseCaseTest {
     fun searchWithExhaustedResultClearsSearchSessionHistoryAndRetries(): TestResult {
         val searchType = SearchUseCase.Type.WithSessionId(TestSearchSessionId)
         val searchWithHistoryResults = listOf(
-            Either.Left(SearchError.Exhausted),
+            Either.Left(SearchError.Exhausted(additionalInfo = "test")),
             Either.Left(SearchError.Empty(additionalInfo = "test"))
         )
         val searchSession = SearchSessionCreator.searchSession(

--- a/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealSearchWithHistoryUseCaseTest.kt
+++ b/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealSearchWithHistoryUseCaseTest.kt
@@ -160,7 +160,7 @@ class RealSearchWithHistoryUseCaseTest {
                 query = TestSearchQuery,
                 searchHistory = searchHistory,
             )
-            assertTrue { actualResult == Either.Left(SearchError.Exhausted) }
+            assertTrue { actualResult == Either.Left(SearchError.Exhausted(additionalInfo = "query=$TestSearchQuery")) }
         }
     }
 


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR adds the query used to exhaust a search to the monitoring log.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
