### PR TITLE
Fix OAuth handler and persist bot tokens

### DIFF
--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackAuth.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/api/ApiSlackAuth.kt
@@ -9,12 +9,15 @@ data class ApiSlackAuthResponse(
     @SerialName("error") val error: String?,
     @SerialName("authed_user") val authedUser: ApiAuthedUser?,
     @SerialName("team") val team: ApiTeam?,
+    @SerialName("scope") val scope: String?,
+    @SerialName("access_token") val accessToken: String?,
+    @SerialName("bot_user_id") val botUserId: String?,
 ) {
     @Serializable
     data class ApiAuthedUser(
         @SerialName("id") val id: String,
-        @SerialName("scope") val scope: String,
-        @SerialName("access_token") val accessToken: String,
+        @SerialName("scope") val scope: String?,
+        @SerialName("access_token") val accessToken: String?,
     )
 
     @Serializable

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuth.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/domain/SlackAuth.kt
@@ -20,13 +20,26 @@ data class SlackAuthState(
     val responseUrl: String,
 )
 
-internal fun ApiSlackAuthResponse.toAuthToken() = SlackAuthToken(
-    id = requireNotNull(authedUser).id,
-    scope = authedUser.scope,
-    token = authedUser.accessToken,
-    teamId = requireNotNull(team).id,
-    teamName = team.name,
-)
+// TODO: Consider better differentiation between the token types
+internal fun ApiSlackAuthResponse.toAuthToken() = if (authedUser?.accessToken != null) {
+    // User token
+    SlackAuthToken(
+        id = requireNotNull(authedUser.id),
+        scope = requireNotNull(authedUser.scope),
+        token = authedUser.accessToken,
+        teamId = requireNotNull(team).id,
+        teamName = team.name,
+    )
+} else {
+    // Bot token
+    SlackAuthToken(
+        id = requireNotNull(botUserId),
+        scope = requireNotNull(scope),
+        token = requireNotNull(accessToken),
+        teamId = requireNotNull(team).id,
+        teamName = team.name,
+    )
+}
 
 internal fun DbSlackAuthToken.toAuthToken() = SlackAuthToken(
     id = id,


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR fixes a bug in the OAuth flow preventing users from installing the app in their workspace. We now also persist the granted initial bot tokens.

## How is this change tested?

Manually and with existing tests.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
